### PR TITLE
GenericV3ListingEngine v0.1 final version

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@3fbca06a403715d658c514459fd3a64535e5c6d6
+    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@main
   release:
     needs: [test]
     uses: bgd-labs/github-workflows/.github/workflows/release.yml@main

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@main
+    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@b6bb2bc34ec61025abb8dde9bd530b9d078e2de7
   release:
     needs: [test]
     uses: bgd-labs/github-workflows/.github/workflows/release.yml@main

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@b6bb2bc34ec61025abb8dde9bd530b9d078e2de7
+    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@c38b6805dd14739b7f22b4d2a3a05dd878defd17
   release:
     needs: [test]
     uses: bgd-labs/github-workflows/.github/workflows/release.yml@main

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@c38b6805dd14739b7f22b4d2a3a05dd878defd17
+    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@3fbca06a403715d658c514459fd3a64535e5c6d6
   release:
     needs: [test]
     uses: bgd-labs/github-workflows/.github/workflows/release.yml@main

--- a/src/v3-listing-engine/GenericV3ListingEngine.sol
+++ b/src/v3-listing-engine/GenericV3ListingEngine.sol
@@ -8,6 +8,7 @@ import {IGenericV3ListingEngine} from './IGenericV3ListingEngine.sol';
 
 /**
  * @dev Helper smart contract implementing a generalized Aave v3 listing flow for a set of assets
+ * Version 0.1
  * It is planned to be used via delegatecall, by any contract having appropriate permissions to
  * do a listing, or any other granular config
  * Assumptions:
@@ -56,18 +57,18 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
 
     AssetsConfig memory configs = _repackListing(listings);
 
-    setPriceFeeds(configs.ids, configs.basics);
+    _setPriceFeeds(configs.ids, configs.basics);
 
-    initAssets(context, configs.ids, configs.basics);
+    _initAssets(context, configs.ids, configs.basics);
 
-    configureCaps(configs.ids, configs.caps);
+    _configureCaps(configs.ids, configs.caps);
 
-    configBorrowSide(configs.ids, configs.borrows);
+    _configBorrowSide(configs.ids, configs.borrows);
 
-    configCollateralSide(configs.ids, configs.collaterals);
+    _configCollateralSide(configs.ids, configs.collaterals);
   }
 
-  function setPriceFeeds(address[] memory ids, Basic[] memory basics) public {
+  function _setPriceFeeds(address[] memory ids, Basic[] memory basics) internal {
     address[] memory assets = new address[](ids.length);
     address[] memory sources = new address[](ids.length);
 
@@ -85,11 +86,11 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
   }
 
   /// @dev mandatory configurations for any asset getting listed, including oracle config and basic init
-  function initAssets(
+  function _initAssets(
     PoolContext memory context,
     address[] memory ids,
     Basic[] memory basics
-  ) public {
+  ) internal {
     ConfiguratorInputTypes.InitReserveInput[]
       memory initReserveInputs = new ConfiguratorInputTypes.InitReserveInput[](ids.length);
     for (uint256 i = 0; i < ids.length; i++) {
@@ -136,7 +137,7 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
     POOL_CONFIGURATOR.initReserves(initReserveInputs);
   }
 
-  function configureCaps(address[] memory ids, Caps[] memory caps) public {
+  function _configureCaps(address[] memory ids, Caps[] memory caps) internal {
     for (uint256 i = 0; i < ids.length; i++) {
       if (caps[i].supplyCap != 0) {
         POOL_CONFIGURATOR.setSupplyCap(ids[i], caps[i].supplyCap);
@@ -148,7 +149,7 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
     }
   }
 
-  function configBorrowSide(address[] memory ids, Borrow[] memory borrows) public {
+  function _configBorrowSide(address[] memory ids, Borrow[] memory borrows) internal {
     for (uint256 i = 0; i < ids.length; i++) {
       if (borrows[i].enabledToBorrow) {
         POOL_CONFIGURATOR.setReserveBorrowing(ids[i], true);
@@ -179,7 +180,7 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
     }
   }
 
-  function configCollateralSide(address[] memory ids, Collateral[] memory collaterals) public {
+  function _configCollateralSide(address[] memory ids, Collateral[] memory collaterals) internal {
     for (uint256 i = 0; i < ids.length; i++) {
       if (collaterals[i].liqThreshold != 0) {
         require(

--- a/src/v3-listing-engine/GenericV3ListingEngine.sol
+++ b/src/v3-listing-engine/GenericV3ListingEngine.sol
@@ -8,7 +8,6 @@ import {IGenericV3ListingEngine} from './IGenericV3ListingEngine.sol';
 
 /**
  * @dev Helper smart contract implementing a generalized Aave v3 listing flow for a set of assets
- * Version 0.1
  * It is planned to be used via delegatecall, by any contract having appropriate permissions to
  * do a listing, or any other granular config
  * Assumptions:
@@ -52,6 +51,7 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
     COLLECTOR = collector;
   }
 
+  /// @inheritdoc IGenericV3ListingEngine
   function listAssets(PoolContext memory context, Listing[] memory listings) public {
     require(listings.length != 0, 'AT_LEAST_ONE_ASSET_REQUIRED');
 
@@ -193,7 +193,9 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
           ids[i],
           collaterals[i].ltv,
           collaterals[i].liqThreshold,
-          100_00 + collaterals[i].liqBonus // Opinionated, seems more correct to define liqBonus as 5_00 for 5%
+          // For reference, this is to simplify the interaction with the Aave protocol,
+          // as there the definition is as e.g. 105% (5% bonus for liquidators)
+          100_00 + collaterals[i].liqBonus
         );
 
         POOL_CONFIGURATOR.setLiquidationProtocolFee(ids[i], collaterals[i].liqProtocolFee);
@@ -217,6 +219,7 @@ contract GenericV3ListingEngine is IGenericV3ListingEngine {
     Caps[] memory caps = new Caps[](listings.length);
 
     for (uint256 i = 0; i < listings.length; i++) {
+      require(listings[i].asset != address(0), 'INVALID_ASSET');
       ids[i] = listings[i].asset;
       basics[i] = Basic({
         assetSymbol: listings[i].assetSymbol,

--- a/src/v3-listing-engine/IGenericV3ListingEngine.sol
+++ b/src/v3-listing-engine/IGenericV3ListingEngine.sol
@@ -96,5 +96,12 @@ interface IGenericV3ListingEngine {
     uint256 borrowCap; // Always configured, no matter if enabled for borrowing or not. Same format as supply cap
   }
 
+  /**
+   * @notice Performs a full listing of an asset in the Aave pool configured in this engine instance
+   * @param context `PoolContext` struct, effectively meta-data for naming of a/v/s tokens.
+   *   More information on the documentation of the struct.
+   * @param listings `Listing[]` list of declarative configs for every aspect of the asset listing.
+   *   More information on the documentation of the struct.
+   */
   function listAssets(PoolContext memory context, Listing[] memory listings) external;
 }


### PR DESCRIPTION
Version of the engine to be used for the initial Aave v3 Ethereum payload.

Only exposing `listAssets()` externally, as the engine is not well prepared yet for more granular updates.