### PR TITLE
fix: use correct minimum version

### DIFF
--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity >=0.7.5 <0.9.0;
+pragma solidity >=0.8.12 <0.9.0;
 
 import 'forge-std/Test.sol';
 import {IAaveOracle, IPool, IPoolAddressesProvider, IPoolDataProvider, IDefaultInterestRateStrategy, DataTypes} from 'aave-address-book/AaveV3.sol';

--- a/src/test/ProtocolV3TestBase.t.sol
+++ b/src/test/ProtocolV3TestBase.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.12;
 
 import 'forge-std/Test.sol';
 import {ProtocolV3TestBase} from '../ProtocolV3TestBase.sol';


### PR DESCRIPTION
https://blog.soliditylang.org/2022/02/16/solidity-0.8.12-release-announcement/ string concat doesn't really work before 8.12