### PR TITLE
feat: update-gov-scripts

### DIFF
--- a/src/GovHelpers.sol
+++ b/src/GovHelpers.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.7.5 <0.9.0;
 pragma abicoder v2;
 
 import {Vm} from 'forge-std/Vm.sol';
-import {Test} from 'forge-std/Test.sol';
 import {console2} from 'forge-std/console2.sol';
 import {AaveGovernanceV2, IAaveGovernanceV2, IExecutorWithTimelock} from 'aave-address-book/AaveGovernanceV2.sol';
 import {IPoolAddressesProvider} from 'aave-address-book/AaveV3.sol';
@@ -35,20 +34,12 @@ library GovHelpers {
   error ExecutorNotFound();
   error LongBytesNotSupportedYet();
 
-  struct SPropCreateParams {
-    address executor;
-    address[] targets;
-    uint256[] values;
-    string[] signatures;
-    bytes[] calldatas;
-    bool[] withDelegatecalls;
-    bytes32 ipfsHash;
-  }
-
   struct Payload {
     address target;
+    uint256 value;
     string signature;
     bytes callData;
+    bool withDelegatecall;
   }
 
   function ipfsHashFile(Vm vm, string memory filePath, bool upload) internal returns (bytes32) {
@@ -85,12 +76,20 @@ library GovHelpers {
   function buildMainnet(address payloadAddress) internal pure returns (Payload memory) {
     require(
       payloadAddress != AaveGovernanceV2.CROSSCHAIN_FORWARDER_OPTIMISM &&
+        payloadAddress != AaveGovernanceV2.CROSSCHAIN_FORWARDER_METIS &&
         payloadAddress != AaveGovernanceV2.CROSSCHAIN_FORWARDER_ARBITRUM &&
         payloadAddress != AaveGovernanceV2.CROSSCHAIN_FORWARDER_POLYGON,
       'PAYLOAD_CANT_BE_FORWARDER'
     );
 
-    return Payload({target: payloadAddress, signature: 'execute()', callData: ''});
+    return
+      Payload({
+        target: payloadAddress,
+        signature: 'execute()',
+        callData: '',
+        value: 0,
+        withDelegatecall: true
+      });
   }
 
   function buildOptimism(address payloadAddress) internal pure returns (Payload memory) {
@@ -132,65 +131,64 @@ library GovHelpers {
     return
       Payload({
         target: forwarder,
+        value: 0,
         signature: 'execute(address)',
-        callData: abi.encode(payloadAddress)
+        callData: abi.encode(payloadAddress),
+        withDelegatecall: true
       });
   }
 
-  function createProposal(
-    Payload[] memory delegateCalls,
-    bytes32 ipfsHash
-  ) internal returns (uint256) {
-    return _createProposal(AaveGovernanceV2.SHORT_EXECUTOR, delegateCalls, ipfsHash, false);
+  function createProposal(Payload[] memory payloads, bytes32 ipfsHash) internal returns (uint256) {
+    return _createProposal(AaveGovernanceV2.SHORT_EXECUTOR, payloads, ipfsHash, false);
   }
 
   function createProposal(
-    Payload[] memory delegateCalls,
+    Payload[] memory payloads,
     bytes32 ipfsHash,
     bool emitLog
   ) internal returns (uint256) {
-    return _createProposal(AaveGovernanceV2.SHORT_EXECUTOR, delegateCalls, ipfsHash, emitLog);
+    return _createProposal(AaveGovernanceV2.SHORT_EXECUTOR, payloads, ipfsHash, emitLog);
   }
 
   function createProposal(
     address executor,
-    Payload[] memory delegateCalls,
+    Payload[] memory payloads,
     bytes32 ipfsHash
   ) internal returns (uint256) {
-    return _createProposal(executor, delegateCalls, ipfsHash, false);
+    return _createProposal(executor, payloads, ipfsHash, false);
   }
 
   function createProposal(
     address executor,
-    Payload[] memory delegateCalls,
+    Payload[] memory payloads,
     bytes32 ipfsHash,
     bool emitLog
   ) internal returns (uint256) {
-    return _createProposal(executor, delegateCalls, ipfsHash, emitLog);
+    return _createProposal(executor, payloads, ipfsHash, emitLog);
   }
 
   function _createProposal(
     address executor,
-    Payload[] memory delegateCalls,
+    Payload[] memory payloads,
     bytes32 ipfsHash,
     bool emitLog
   ) private returns (uint256) {
     require(block.chainid == ChainIds.MAINNET, 'MAINNET_ONLY');
-    require(delegateCalls.length != 0, 'MINIMUM_ONE_PAYLOAD');
+    require(payloads.length != 0, 'MINIMUM_ONE_PAYLOAD');
     require(ipfsHash != bytes32(0), 'NON_ZERO_IPFS_HASH');
 
-    address[] memory targets = new address[](delegateCalls.length);
-    uint256[] memory values = new uint256[](delegateCalls.length);
-    string[] memory signatures = new string[](delegateCalls.length);
-    bytes[] memory calldatas = new bytes[](delegateCalls.length);
-    bool[] memory withDelegatecalls = new bool[](delegateCalls.length);
-    for (uint256 i = 0; i < delegateCalls.length; i++) {
-      require(delegateCalls[i].target != address(0), 'NON_ZERO_TARGET');
-      targets[i] = delegateCalls[i].target;
-      signatures[i] = delegateCalls[i].signature;
-      calldatas[i] = delegateCalls[i].callData;
-      values[i] = 0;
-      withDelegatecalls[i] = true;
+    address[] memory targets = new address[](payloads.length);
+    uint256[] memory values = new uint256[](payloads.length);
+    string[] memory signatures = new string[](payloads.length);
+    bytes[] memory calldatas = new bytes[](payloads.length);
+    bool[] memory withDelegatecalls = new bool[](payloads.length);
+    for (uint256 i = 0; i < payloads.length; i++) {
+      require(payloads[i].target != address(0), 'NON_ZERO_TARGET');
+      targets[i] = payloads[i].target;
+      signatures[i] = payloads[i].signature;
+      calldatas[i] = payloads[i].callData;
+      values[i] = payloads[i].value;
+      withDelegatecalls[i] = payloads[i].withDelegatecall;
     }
 
     if (emitLog) {
@@ -223,30 +221,18 @@ library GovHelpers {
   /**
    * @dev Impersonate the ecosystem reserve and creates the proposal.
    */
-  function createTestProposal(Vm vm, SPropCreateParams memory params) internal returns (uint256) {
+  function createTestProposal(
+    Vm vm,
+    address executor,
+    Payload[] memory payloads
+  ) internal returns (uint256) {
     vm.deal(AaveMisc.ECOSYSTEM_RESERVE, 1 ether);
     vm.startPrank(AaveMisc.ECOSYSTEM_RESERVE);
-    uint256 proposalId = AaveGovernanceV2.GOV.create(
-      IExecutorWithTimelock(params.executor),
-      params.targets,
-      params.values,
-      params.signatures,
-      params.calldatas,
-      params.withDelegatecalls,
-      params.ipfsHash
-    );
+    uint256 proposalId = _createProposal(executor, payloads, bytes32('test'), false);
     vm.stopPrank();
     return proposalId;
   }
 
-  function _getProposalSlot(uint256 proposalId) private pure returns (bytes32 slot) {
-    uint256 proposalsMapSlot = 0x4;
-    return bytes32(uint256(keccak256(abi.encode(proposalId, proposalsMapSlot))) + 11);
-  }
-
-  /**
-   * Alter storage slots so the proposal passes
-   */
   function passVoteAndExecute(Vm vm, uint256 proposalId) internal {
     passVoteAndQueue(vm, proposalId);
     uint256 executionTime = AaveGovernanceV2.GOV.getProposalById(proposalId).executionTime;
@@ -259,28 +245,28 @@ library GovHelpers {
     AaveGovernanceV2.GOV.queue(proposalId);
   }
 
+  /**
+   * Alter storage slots so the proposal passes
+   */
   function passVote(Vm vm, uint256 proposalId) internal {
     uint256 power = 5000000 ether;
     vm.roll(block.number + 1);
-    vm.store(address(AaveGovernanceV2.GOV), _getProposalSlot(proposalId), bytes32(power));
+    vm.store(
+      address(AaveGovernanceV2.GOV),
+      bytes32(uint256(keccak256(abi.encode(proposalId, 0x4))) + 11),
+      bytes32(power)
+    );
     uint256 endBlock = AaveGovernanceV2.GOV.getProposalById(proposalId).endBlock;
     vm.roll(endBlock + 1);
-  }
-
-  function getProposalById(
-    uint256 proposalId
-  ) internal view returns (IAaveGovernanceV2.ProposalWithoutVotes memory) {
-    return AaveGovernanceV2.GOV.getProposalById(proposalId);
   }
 
   /**
    * @dev executes latest actionset on a l2 executor
    * @param vm Vm instance passed down from test
    */
-  function executeLatestActionSet(Vm vm) internal {
-    address executor = _getExecutor();
+  function executeLatestActionSet(Vm vm, address executor) internal {
     uint256 proposalCount = uint256(vm.load(executor, bytes32(uint256(5))));
-    executeActionSet(vm, proposalCount - 1);
+    executeActionSet(vm, executor, proposalCount - 1);
   }
 
   /**
@@ -288,44 +274,43 @@ library GovHelpers {
    * @param vm Vm instance passed down from test
    * @param actionSetId id of actionset to execute
    */
-  function executeActionSet(Vm vm, uint256 actionSetId) internal {
-    address executor = _getExecutor();
+  function executeActionSet(Vm vm, address executor, uint256 actionSetId) internal {
     uint256 proposalBaseSlot = StorageHelpers.getStorageSlotUintMapping(6, actionSetId);
     vm.store(executor, bytes32(proposalBaseSlot + 5), bytes32(block.timestamp));
     CommonExecutor(executor).execute(actionSetId);
   }
 
   /**
-   * @dev executes specified payloadAddress on a l2 executor via proposalExecution
-   * This method automatically picks the correct executor based on the current chain
-   * @notice this method only acceps executors, not guardians
-   * @param vm Vm instance passed down from test
-   * @param payloadAddress address of payload to execute
-   */
-  function executePayload(Vm vm, address payloadAddress) internal {
-    address executor = _getExecutor();
-    executePayload(vm, payloadAddress, executor);
-  }
-
-  /**
    * @dev executes specified payloadAddress on a specified executor via delegatecall
    * @notice this method accepts arbitrary executors (guardians and executors)
    * @param vm Vm instance passed down from test
-   * @param payloadAddress address of payload to execute
    * @param executor address of the executor
+   * @param payloadAddress address of payload to execute
    */
-  function executePayload(Vm vm, address payloadAddress, address executor) internal {
+  function executePayload(Vm vm, address executor, address payloadAddress) internal {
     if (
       block.chainid == ChainIds.MAINNET &&
       (executor == AaveGovernanceV2.SHORT_EXECUTOR || executor == AaveGovernanceV2.LONG_EXECUTOR)
     ) {
       Payload[] memory proposals = new Payload[](1);
-      proposals[0] = Payload(payloadAddress, 'execute()', '');
+      proposals[0] = Payload({
+        target: payloadAddress,
+        signature: 'execute()',
+        callData: '',
+        withDelegatecall: true,
+        value: 0
+      });
       uint256 proposalId = _queueProposalToL1ExecutorStorage(vm, executor, proposals);
       AaveGovernanceV2.GOV.execute(proposalId);
-    } else if (_getExecutor() == executor) {
+    } else if (_isKnownL2Executor(executor)) {
       Payload[] memory proposals = new Payload[](1);
-      proposals[0] = Payload(payloadAddress, 'execute()', '');
+      proposals[0] = Payload({
+        target: payloadAddress,
+        signature: 'execute()',
+        callData: '',
+        withDelegatecall: true,
+        value: 0
+      });
       uint256 proposalId = _queueProposalToL2ExecutorStorage(vm, executor, proposals);
       CommonExecutor(executor).execute(proposalId);
     } else {
@@ -577,12 +562,20 @@ library GovHelpers {
     return proposalCount;
   }
 
-  function _getExecutor() internal view returns (address) {
-    if (block.chainid == ChainIds.OPTIMISM) return AaveGovernanceV2.OPTIMISM_BRIDGE_EXECUTOR;
-    if (block.chainid == ChainIds.POLYGON) return AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR;
-    if (block.chainid == ChainIds.METIS) return AaveGovernanceV2.METIS_BRIDGE_EXECUTOR;
-    if (block.chainid == ChainIds.ARBITRUM) return AaveGovernanceV2.ARBITRUM_BRIDGE_EXECUTOR;
-    return address(0);
+  function _isKnownL2Executor(address executor) internal view returns (bool) {
+    console2.log(executor);
+    console2.log(block.chainid);
+    if (executor == AaveGovernanceV2.OPTIMISM_BRIDGE_EXECUTOR && block.chainid == ChainIds.OPTIMISM)
+      return true;
+    if (executor == AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR && block.chainid == ChainIds.POLYGON)
+      return true;
+    if (executor == AaveGovernanceV2.METIS_BRIDGE_EXECUTOR && block.chainid == ChainIds.METIS)
+      return true;
+    if (executor == AaveGovernanceV2.ARBITRUM_BRIDGE_EXECUTOR && block.chainid == ChainIds.ARBITRUM)
+      return true;
+    // not a l2, but following same interface & stroage
+    if (executor == AaveGovernanceV2.ARC_TIMELOCK && block.chainid == ChainIds.MAINNET) return true;
+    return false;
   }
 }
 
@@ -597,25 +590,5 @@ contract MockExecutor {
   function execute(address payload) public {
     (bool success, ) = payload.delegatecall(abi.encodeWithSignature('execute()'));
     require(success, 'PROPOSAL_EXECUTION_FAILED');
-  }
-}
-
-/**
- * @dev Inheriting from this contract in a forge test allows to
- * @notice @deprecated kept, to not break existing tests
- * 1. Configure on the setUp() of the child contract an executor for governance proposals
- *    (or any address with permissions) just by doing for example a `_selectPayloadExecutor(AaveGovernanceV2.SHORT_EXECUTOR)`
- * 2. Afterwards, on a test you can just do `_executePayload(somePayloadAddress)`, and it will be executed via
- *    DELEGATECALL on the address previously selected on step 1).
- */
-abstract contract TestWithExecutor is Test {
-  address internal _executor;
-
-  function _selectPayloadExecutor(address executor) internal {
-    _executor = executor;
-  }
-
-  function _executePayload(address payloadAddress) internal {
-    GovHelpers.executePayload(vm, payloadAddress, _executor);
   }
 }

--- a/src/GovHelpers.sol
+++ b/src/GovHelpers.sol
@@ -151,18 +151,18 @@ library GovHelpers {
   }
 
   function createProposal(
-    address executor,
     Payload[] memory payloads,
-    bytes32 ipfsHash
+    bytes32 ipfsHash,
+    address executor
   ) internal returns (uint256) {
     return _createProposal(executor, payloads, ipfsHash, false);
   }
 
   function createProposal(
-    address executor,
     Payload[] memory payloads,
     bytes32 ipfsHash,
-    bool emitLog
+    bool emitLog,
+    address executor
   ) internal returns (uint256) {
     return _createProposal(executor, payloads, ipfsHash, emitLog);
   }
@@ -223,8 +223,8 @@ library GovHelpers {
    */
   function createTestProposal(
     Vm vm,
-    address executor,
-    Payload[] memory payloads
+    Payload[] memory payloads,
+    address executor
   ) internal returns (uint256) {
     vm.deal(AaveMisc.ECOSYSTEM_RESERVE, 1 ether);
     vm.startPrank(AaveMisc.ECOSYSTEM_RESERVE);
@@ -266,7 +266,7 @@ library GovHelpers {
    */
   function executeLatestActionSet(Vm vm, address executor) internal {
     uint256 proposalCount = uint256(vm.load(executor, bytes32(uint256(5))));
-    executeActionSet(vm, executor, proposalCount - 1);
+    executeActionSet(vm, proposalCount - 1, executor);
   }
 
   /**
@@ -274,7 +274,7 @@ library GovHelpers {
    * @param vm Vm instance passed down from test
    * @param actionSetId id of actionset to execute
    */
-  function executeActionSet(Vm vm, address executor, uint256 actionSetId) internal {
+  function executeActionSet(Vm vm, uint256 actionSetId, address executor) internal {
     uint256 proposalBaseSlot = StorageHelpers.getStorageSlotUintMapping(6, actionSetId);
     vm.store(executor, bytes32(proposalBaseSlot + 5), bytes32(block.timestamp));
     CommonExecutor(executor).execute(actionSetId);
@@ -287,7 +287,7 @@ library GovHelpers {
    * @param executor address of the executor
    * @param payloadAddress address of payload to execute
    */
-  function executePayload(Vm vm, address executor, address payloadAddress) internal {
+  function executePayload(Vm vm, address payloadAddress, address executor) internal {
     if (
       block.chainid == ChainIds.MAINNET &&
       (executor == AaveGovernanceV2.SHORT_EXECUTOR || executor == AaveGovernanceV2.LONG_EXECUTOR)
@@ -563,8 +563,6 @@ library GovHelpers {
   }
 
   function _isKnownL2Executor(address executor) internal view returns (bool) {
-    console2.log(executor);
-    console2.log(block.chainid);
     if (executor == AaveGovernanceV2.OPTIMISM_BRIDGE_EXECUTOR && block.chainid == ChainIds.OPTIMISM)
       return true;
     if (executor == AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR && block.chainid == ChainIds.POLYGON)

--- a/tests/AaveV2ConfigEngineTest.t.sol
+++ b/tests/AaveV2ConfigEngineTest.t.sol
@@ -9,10 +9,10 @@ import {AaveV2Ethereum} from 'aave-address-book/AaveAddressBook.sol';
 import {AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
 import {AaveGovernanceV2} from 'aave-address-book/AaveGovernanceV2.sol';
 import {IV2RateStrategyFactory} from '../src/v2-config-engine/IV2RateStrategyFactory.sol';
-import {TestWithExecutor} from '../src/GovHelpers.sol';
+import {GovHelpers} from '../src/GovHelpers.sol';
 import '../src/ProtocolV2TestBase.sol';
 
-contract AaveV2ConfigEngineTest is ProtocolV2TestBase, TestWithExecutor {
+contract AaveV2ConfigEngineTest is ProtocolV2TestBase {
   using stdStorage for StdStorage;
 
   function testV2RateStrategiesUpdates() public {
@@ -32,8 +32,7 @@ contract AaveV2ConfigEngineTest is ProtocolV2TestBase, TestWithExecutor {
 
     createConfigurationSnapshot('preTestV2RatesUpdates', AaveV2Ethereum.POOL);
 
-    _selectPayloadExecutor(AaveGovernanceV2.SHORT_EXECUTOR);
-    _executePayload(address(payload));
+    GovHelpers.executePayload(vm, AaveGovernanceV2.SHORT_EXECUTOR, address(payload));
 
     createConfigurationSnapshot('postTestV2RatesUpdates', AaveV2Ethereum.POOL);
 

--- a/tests/AaveV2ConfigEngineTest.t.sol
+++ b/tests/AaveV2ConfigEngineTest.t.sol
@@ -32,7 +32,7 @@ contract AaveV2ConfigEngineTest is ProtocolV2TestBase {
 
     createConfigurationSnapshot('preTestV2RatesUpdates', AaveV2Ethereum.POOL);
 
-    GovHelpers.executePayload(vm, AaveGovernanceV2.SHORT_EXECUTOR, address(payload));
+    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.SHORT_EXECUTOR);
 
     createConfigurationSnapshot('postTestV2RatesUpdates', AaveV2Ethereum.POOL);
 

--- a/tests/AaveV3ConfigEngineGauntletProposal.t.sol
+++ b/tests/AaveV3ConfigEngineGauntletProposal.t.sol
@@ -15,10 +15,10 @@ import {AaveV3AvalancheRatesUpdates070322} from './mocks/gauntlet-updates/AaveV3
 import {AaveV3OptimismRatesUpdates070322} from './mocks/gauntlet-updates/AaveV3OptimismRatesUpdates070322.sol';
 import {AaveV3ArbitrumRatesUpdates070322} from './mocks/gauntlet-updates/AaveV3ArbitrumRatesUpdates070322.sol';
 import {DeployEnginePolLib, DeployEngineEthLib, DeployEngineAvaLib, DeployEngineOptLib, DeployEngineArbLib} from '../scripts/AaveV3ConfigEngine.s.sol';
-import {GovHelpers, TestWithExecutor} from '../src/GovHelpers.sol';
+import {GovHelpers} from '../src/GovHelpers.sol';
 import '../src/ProtocolV3TestBase.sol';
 
-contract AaveV3PolygonConfigEngineRatesTest is ProtocolV3TestBase, TestWithExecutor {
+contract AaveV3PolygonConfigEngineRatesTest is ProtocolV3TestBase {
   using stdStorage for StdStorage;
 
   function setUp() public {
@@ -31,7 +31,7 @@ contract AaveV3PolygonConfigEngineRatesTest is ProtocolV3TestBase, TestWithExecu
 
     createConfigurationSnapshot('preTestEnginePolV3Gauntlet', AaveV3Polygon.POOL);
 
-    GovHelpers.executePayload(vm, address(payload));
+    GovHelpers.executePayload(vm, AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR, address(payload));
 
     createConfigurationSnapshot('postTestEnginePolV3Gauntlet', AaveV3Polygon.POOL);
 
@@ -39,7 +39,7 @@ contract AaveV3PolygonConfigEngineRatesTest is ProtocolV3TestBase, TestWithExecu
   }
 }
 
-contract AaveV3AvalancheConfigEngineRatesTest is ProtocolV3TestBase, TestWithExecutor {
+contract AaveV3AvalancheConfigEngineRatesTest is ProtocolV3TestBase {
   using stdStorage for StdStorage;
 
   function setUp() public {
@@ -52,7 +52,7 @@ contract AaveV3AvalancheConfigEngineRatesTest is ProtocolV3TestBase, TestWithExe
 
     createConfigurationSnapshot('preTestEngineAvaV3Gauntlet', AaveV3Avalanche.POOL);
 
-    GovHelpers.executePayload(vm, address(payload), 0xa35b76E4935449E33C56aB24b23fcd3246f13470); // Aave Avalanche's Guardian
+    GovHelpers.executePayload(vm, 0xa35b76E4935449E33C56aB24b23fcd3246f13470, address(payload)); // Aave Avalanche's Guardian
 
     createConfigurationSnapshot('postTestEngineAvaV3Gauntlet', AaveV3Avalanche.POOL);
 
@@ -73,7 +73,7 @@ contract AaveV3OptimismConfigEngineRatesTest is ProtocolV3TestBase {
 
     createConfigurationSnapshot('preTestEngineOptV3Gauntlet', AaveV3Optimism.POOL);
 
-    GovHelpers.executePayload(vm, address(payload));
+    GovHelpers.executePayload(vm, AaveGovernanceV2.OPTIMISM_BRIDGE_EXECUTOR, address(payload));
 
     createConfigurationSnapshot('postTestEngineOptV3Gauntlet', AaveV3Optimism.POOL);
 
@@ -94,7 +94,7 @@ contract AaveV3ArbitrumConfigEngineRatesTest is ProtocolV3TestBase {
 
     createConfigurationSnapshot('preTestEngineArbV3Gauntlet', AaveV3Arbitrum.POOL);
 
-    GovHelpers.executePayload(vm, address(payload));
+    GovHelpers.executePayload(vm, AaveGovernanceV2.ARBITRUM_BRIDGE_EXECUTOR, address(payload));
 
     createConfigurationSnapshot('postTestEngineArbV3Gauntlet', AaveV3Arbitrum.POOL);
 

--- a/tests/AaveV3ConfigEngineGauntletProposal.t.sol
+++ b/tests/AaveV3ConfigEngineGauntletProposal.t.sol
@@ -31,7 +31,7 @@ contract AaveV3PolygonConfigEngineRatesTest is ProtocolV3TestBase {
 
     createConfigurationSnapshot('preTestEnginePolV3Gauntlet', AaveV3Polygon.POOL);
 
-    GovHelpers.executePayload(vm, AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR, address(payload));
+    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR);
 
     createConfigurationSnapshot('postTestEnginePolV3Gauntlet', AaveV3Polygon.POOL);
 
@@ -52,7 +52,7 @@ contract AaveV3AvalancheConfigEngineRatesTest is ProtocolV3TestBase {
 
     createConfigurationSnapshot('preTestEngineAvaV3Gauntlet', AaveV3Avalanche.POOL);
 
-    GovHelpers.executePayload(vm, 0xa35b76E4935449E33C56aB24b23fcd3246f13470, address(payload)); // Aave Avalanche's Guardian
+    GovHelpers.executePayload(vm, address(payload), 0xa35b76E4935449E33C56aB24b23fcd3246f13470); // Aave Avalanche's Guardian
 
     createConfigurationSnapshot('postTestEngineAvaV3Gauntlet', AaveV3Avalanche.POOL);
 
@@ -73,7 +73,7 @@ contract AaveV3OptimismConfigEngineRatesTest is ProtocolV3TestBase {
 
     createConfigurationSnapshot('preTestEngineOptV3Gauntlet', AaveV3Optimism.POOL);
 
-    GovHelpers.executePayload(vm, AaveGovernanceV2.OPTIMISM_BRIDGE_EXECUTOR, address(payload));
+    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.OPTIMISM_BRIDGE_EXECUTOR);
 
     createConfigurationSnapshot('postTestEngineOptV3Gauntlet', AaveV3Optimism.POOL);
 
@@ -94,7 +94,7 @@ contract AaveV3ArbitrumConfigEngineRatesTest is ProtocolV3TestBase {
 
     createConfigurationSnapshot('preTestEngineArbV3Gauntlet', AaveV3Arbitrum.POOL);
 
-    GovHelpers.executePayload(vm, AaveGovernanceV2.ARBITRUM_BRIDGE_EXECUTOR, address(payload));
+    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.ARBITRUM_BRIDGE_EXECUTOR);
 
     createConfigurationSnapshot('postTestEngineArbV3Gauntlet', AaveV3Arbitrum.POOL);
 

--- a/tests/GovTest.t.sol
+++ b/tests/GovTest.t.sol
@@ -44,7 +44,7 @@ contract GovernanceL2ExecutorTest is Test {
     PayloadWithEmit payload = new PayloadWithEmit();
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executePayload(vm, AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR, address(payload));
+    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR);
   }
 }
 
@@ -59,14 +59,14 @@ contract GovernanceMainnetExecutorTest is Test {
     PayloadWithEmit payload = new PayloadWithEmit();
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executePayload(vm, AaveGovernanceV2.SHORT_EXECUTOR, address(payload));
+    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.SHORT_EXECUTOR);
   }
 
   function testCreateProposalLong() public {
     PayloadWithEmit payload = new PayloadWithEmit();
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executePayload(vm, AaveGovernanceV2.LONG_EXECUTOR, address(payload));
+    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.LONG_EXECUTOR);
   }
 }
 

--- a/tests/GovTest.t.sol
+++ b/tests/GovTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import 'forge-std/Test.sol';
-import {GovHelpers, TestWithExecutor} from '../src/GovHelpers.sol';
+import {GovHelpers} from '../src/GovHelpers.sol';
 import {AaveMisc} from 'aave-address-book/AaveMisc.sol';
 import {AaveGovernanceV2} from 'aave-address-book/AaveGovernanceV2.sol';
 import {PayloadWithEmit} from './mocks/PayloadWithEmit.sol';
@@ -44,7 +44,7 @@ contract GovernanceL2ExecutorTest is Test {
     PayloadWithEmit payload = new PayloadWithEmit();
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executePayload(vm, address(payload));
+    GovHelpers.executePayload(vm, AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR, address(payload));
   }
 }
 
@@ -59,14 +59,14 @@ contract GovernanceMainnetExecutorTest is Test {
     PayloadWithEmit payload = new PayloadWithEmit();
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.SHORT_EXECUTOR);
+    GovHelpers.executePayload(vm, AaveGovernanceV2.SHORT_EXECUTOR, address(payload));
   }
 
   function testCreateProposalLong() public {
     PayloadWithEmit payload = new PayloadWithEmit();
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executePayload(vm, address(payload), AaveGovernanceV2.LONG_EXECUTOR);
+    GovHelpers.executePayload(vm, AaveGovernanceV2.LONG_EXECUTOR, address(payload));
   }
 }
 

--- a/tests/crosschainforwarders/ArbitrumCrossChainForwarderTest.t.sol
+++ b/tests/crosschainforwarders/ArbitrumCrossChainForwarderTest.t.sol
@@ -71,8 +71,10 @@ contract ArbitrumCrossChainForwarderTest is ProtocolV3TestBase {
     GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](1);
     payloads[0] = GovHelpers.Payload({
       target: address(forwarder),
+      value: 0,
       signature: 'execute(address)',
-      callData: abi.encode(address(payloadWithEmit))
+      callData: abi.encode(address(payloadWithEmit)),
+      withDelegatecall: true
     });
 
     uint256 proposalId = GovHelpers.createProposal(
@@ -141,6 +143,6 @@ contract ArbitrumCrossChainForwarderTest is ProtocolV3TestBase {
     // 4. execute the proposal
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executeLatestActionSet(vm);
+    GovHelpers.executeLatestActionSet(vm, ARBITRUM_BRIDGE_EXECUTOR);
   }
 }

--- a/tests/crosschainforwarders/MetisCrossChainForwarderTest.t.sol
+++ b/tests/crosschainforwarders/MetisCrossChainForwarderTest.t.sol
@@ -42,8 +42,10 @@ contract MetisCrossChainForwarderTest is ProtocolV3TestBase {
     GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](1);
     payloads[0] = GovHelpers.Payload({
       target: address(forwarder),
+      value: 0,
       signature: 'execute(address)',
-      callData: abi.encode(address(payloadWithEmit))
+      callData: abi.encode(address(payloadWithEmit)),
+      withDelegatecall: true
     });
 
     uint256 proposalId = GovHelpers.createProposal(payloads, 'ipfs');
@@ -72,6 +74,6 @@ contract MetisCrossChainForwarderTest is ProtocolV3TestBase {
     // 4. execute proposal on l2
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executeLatestActionSet(vm);
+    GovHelpers.executeLatestActionSet(vm, METIS_BRIDGE_EXECUTOR);
   }
 }

--- a/tests/crosschainforwarders/OptimismCrossChainForwarderTest.t.sol
+++ b/tests/crosschainforwarders/OptimismCrossChainForwarderTest.t.sol
@@ -42,6 +42,8 @@ contract OptimismCrossChainForwarderTest is ProtocolV3TestBase {
     vm.startPrank(AaveMisc.ECOSYSTEM_RESERVE);
     GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](1);
     payloads[0] = GovHelpers.Payload({
+      value: 0,
+      withDelegatecall: true,
       target: address(forwarder),
       signature: 'execute(address)',
       callData: abi.encode(address(payloadWithEmit))
@@ -73,6 +75,6 @@ contract OptimismCrossChainForwarderTest is ProtocolV3TestBase {
     // 4. execute proposal on l2
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executeLatestActionSet(vm);
+    GovHelpers.executeLatestActionSet(vm, OPTIMISM_BRIDGE_EXECUTOR);
   }
 }

--- a/tests/crosschainforwarders/PolygonCrossChainForwarderTest.t.sol
+++ b/tests/crosschainforwarders/PolygonCrossChainForwarderTest.t.sol
@@ -23,7 +23,7 @@ contract PolygonCrossChainForwarderTest is ProtocolV3TestBase {
 
   address public constant FX_CHILD_ADDRESS = 0x8397259c983751DAf40400790063935a11afa28a;
 
-  address public constant POLYGON_BRIDGE_EXECUTOR = 0xdc9A35B16DB4e126cFeDC41322b3a36454B1F772;
+  address public constant POLYGON_BRIDGE_EXECUTOR = AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR;
 
   PayloadWithEmit public payloadWithEmit;
 
@@ -47,6 +47,8 @@ contract PolygonCrossChainForwarderTest is ProtocolV3TestBase {
     vm.startPrank(AaveMisc.ECOSYSTEM_RESERVE);
     GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](1);
     payloads[0] = GovHelpers.Payload({
+      value: 0,
+      withDelegatecall: true,
       target: address(forwarder),
       signature: 'execute(address)',
       callData: abi.encode(address(payloadWithEmit))
@@ -78,6 +80,6 @@ contract PolygonCrossChainForwarderTest is ProtocolV3TestBase {
     // 4. Forward time & execute proposal
     vm.expectEmit(true, true, true, true);
     emit TestEvent();
-    GovHelpers.executeLatestActionSet(vm);
+    GovHelpers.executeLatestActionSet(vm, POLYGON_BRIDGE_EXECUTOR);
   }
 }


### PR DESCRIPTION
Motivation:
over time we created multiple ways to do the same things, I think it's time to cleanup a bit (although this might be slightly breaking) and align on a single path.

We have the `buildOptimism` etc methods which only allow withDelegatecall: true & value: 0 parameters
We have the `SPropCreateParams` which allows to do anything but requires relatively cumbersome creation of arrays etc.
We have `executePayload` and `executeLatestActionSet` which "guesses the executor" based on the chain - which is problematic when there are multiple executors (like on mainnet).

This pr extends `Payload` to accept value & withDelegatecall, so it's suited for all kinds of payloads.
At the same time it removes SPropCreateParams


---

We currently have `TestWithExecutor` which doesn't work quite well when you got a multichain test and is just unnecessary now as GovHelpers works for all chains.