### PR TITLE
reproduction

### DIFF
--- a/src/ProtocolV2TestBase.sol
+++ b/src/ProtocolV2TestBase.sol
@@ -156,10 +156,8 @@ contract ProtocolV2TestBase is CommonTestBase {
     uint256 amount,
     bool stable
   ) internal {
-    uint256 snapshot = vm.snapshot();
     this._borrow(testAssetConfig, pool, borrower, amount, stable);
     _repay(testAssetConfig, pool, borrower, amount, stable);
-    vm.revertTo(snapshot);
   }
 
   /**


### PR DESCRIPTION
This is a reproduction for https://github.com/foundry-rs/foundry/issues/5118

You can reproduce by running: `forge test --match-contract ProtocolV2TestE2ETestAsset -vv` and the test will fail.

The test will call:
```solidity
contract ProtocolV2TestE2ETestAsset is ProtocolV2TestBase {
  function setUp() public {
    vm.createSelectFork('mainnet', 17627440);
  }

  function test_e2eTestAssetUSDT() public {
    ReserveConfig[] memory configs = _getReservesConfigs(AaveV2Ethereum.POOL);
    e2eTestAsset(
      AaveV2Ethereum.POOL,
      _findReserveConfig(configs, AaveV2EthereumAssets.DAI_UNDERLYING),
      _findReserveConfig(configs, AaveV2EthereumAssets.USDT_UNDERLYING)
    );
  }
}
```

This in turn calls:
```
function e2eTestAsset(
    ILendingPool pool,
    ReserveConfig memory collateralConfig,
    ReserveConfig memory testAssetConfig
  ) public {
    console.log(
      'E2E: Collateral %s, TestAsset %s',
      collateralConfig.symbol,
      testAssetConfig.symbol
    );
    address collateralSupplier = vm.addr(3);
    address testAssetSupplier = vm.addr(4);
    require(collateralConfig.usageAsCollateralEnabled, 'COLLATERAL_CONFIG_MUST_BE_COLLATERAL');
    uint256 testAssetAmount = _getTokenAmountByEthValue(pool, testAssetConfig, 1);
    _deposit(
      collateralConfig,
      pool,
      collateralSupplier,
      _getTokenAmountByEthValue(pool, collateralConfig, 100)
    );
    _deposit(testAssetConfig, pool, testAssetSupplier, testAssetAmount);
    uint256 snapshot = vm.snapshot(); // HERE a snapshot is created
    // test withdrawal
    _withdraw(testAssetConfig, pool, testAssetSupplier, testAssetAmount / 2);
    _withdraw(testAssetConfig, pool, testAssetSupplier, type(uint256).max);
    vm.revertTo(snapshot); // HERE we revert to it
    // test variable borrowing
    if (testAssetConfig.borrowingEnabled) {
      _e2eTestBorrowRepay(pool, collateralSupplier, testAssetConfig, testAssetAmount, false);
      vm.revertTo(snapshot); // HERE we revert to it
      // test stable borrowing
      if (testAssetConfig.stableBorrowRateEnabled) {
        _e2eTestBorrowRepay(pool, collateralSupplier, testAssetConfig, testAssetAmount, true);
        vm.revertTo(snapshot); // HERE we revert to it
      }
    }
  }
  ```

The code changed in the pr should in fact not have any effect as after calling `_e2eTestBorrowRepay` we revert to the previous test, but as you can see removing the additional revert will break the test.