### PR TITLE
Use collateral with ltv > 15%

### DIFF
--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -214,6 +214,8 @@ contract ProtocolV3TestBase is CommonTestBase {
         configs[i].usageAsCollateralEnabled &&
         // not stable borrowable as this makes testing stable borrowing unnecessary hard to reason about
         !configs[i].stableBorrowRateEnabled &&
+        // LTV is higher than 15%
+        configs[i].ltv > 1500 &&
         // supply cap not yet reached
         ((configs[i].supplyCap * 10 ** configs[i].decimals) >
           IERC20(configs[i].aToken).totalSupply()) &&


### PR DESCRIPTION
We make an assumption "good collateral" has an ltv of at least 10% in the $1000 collateral vs $100 borrows. Putting 15% for some small buffer.