### PR TITLE
fix: rely on local npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,48 @@
 
 This package contains various contracts which allow you to streamline testing within the aave protocol in foundry.
 
-## GovHelpers (deprecated)
+## Development
+
+This project uses [Foundry](https://getfoundry.sh). See the [book](https://book.getfoundry.sh/getting-started/installation.html) for detailed instructions on how to install and use Foundry.
+
+Some of the tooling relies on external calls via ffi to [aave-cli](https://github.com/bgd-labs/aave-cli).
+Therefore you need to install aave-cli locally.
+
+## Setup
+
+```sh
+cp .env.example .env
+forge install
+yarn
+```
+
+## Usage
+
+### GovHelpers (deprecated)
 
 These helpers allow you to create and execute proposals on L1 so you don't have to care about having enough proposition power, timings, etc.
 
-## GovV3Helpers
+### GovV3Helpers
 
 These helpers allow the creation of proposal for aave governance v3.
 
 The GovernanceV3Helpers also contain scripts to cast a vote directly via foundry.
 To do so just run `make vote proposalId=n support=true/false`.
 
-## ProxyHelpers
+### ProxyHelpers
 
 These helpers allow you to fetch the current implementation & admin for a specified proxy.
 
-## BridgeExecutorHelpers
+### BridgeExecutorHelpers
 
 These helpers allow you to simulate execution of proposals on governance controlled Aave V2/V3 pools.
 
-## ProtocolV3TestBase
+### ProtocolV3TestBase
 
 The ProtocolV3TestBase is intended to be used with proposals that alter a V3 pool. While the `helpers` are libraries, you can use from where ever you want `ProtocolV3TestBase` is intended to be inherited from in your test via `is ProtocolV3TestBase`.
 
 When inheriting from `ProtocolV3TestBase` you have access to methods to create readable configuration snapshots of a pool and e2e tests of a pool.
 
-## ProtocolV2TestBase
+### ProtocolV2TestBase
 
 Analog to ProtocolV3TestBase but for v2 pools.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "prettier-plugin-solidity": "^1.1.3"
   },
   "dependencies": {
-    "@bgd-labs/aave-cli": "0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0"
+    "@bgd-labs/aave-cli": "^0.1.0"
   }
 }

--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -127,16 +127,14 @@ contract CommonTestBase is Test {
     string memory beforePath = string(abi.encodePacked('./reports/', reportBefore, '.json'));
     string memory afterPath = string(abi.encodePacked('./reports/', reportAfter, '.json'));
 
-    string[] memory inputs = new string[](9);
+    string[] memory inputs = new string[](7);
     inputs[0] = 'npx';
-    inputs[1] = '--yes';
-    inputs[2] = '-s';
-    inputs[3] = '@bgd-labs/aave-cli@0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0';
-    inputs[4] = 'diff-snapshots';
-    inputs[5] = beforePath;
-    inputs[6] = afterPath;
-    inputs[7] = '-o';
-    inputs[8] = outPath;
+    inputs[1] = '@bgd-labs/aave-cli@0.1.0';
+    inputs[2] = 'diff-snapshots';
+    inputs[3] = beforePath;
+    inputs[4] = afterPath;
+    inputs[5] = '-o';
+    inputs[6] = outPath;
     vm.ffi(inputs);
   }
 

--- a/src/GovV3Helpers.sol
+++ b/src/GovV3Helpers.sol
@@ -89,17 +89,15 @@ library GovV3Helpers {
     uint256 proposalId,
     address voter
   ) internal returns (IVotingMachineWithProofs.VotingBalanceProof[] memory) {
-    string[] memory inputs = new string[](10);
+    string[] memory inputs = new string[](8);
     inputs[0] = 'npx';
-    inputs[1] = '--yes';
-    inputs[2] = '-s';
-    inputs[3] = '@bgd-labs/aave-cli@0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0';
-    inputs[4] = 'governance';
-    inputs[5] = 'getVotingProofs';
-    inputs[6] = '--proposalId';
-    inputs[7] = vm.toString(proposalId);
-    inputs[8] = '--voter';
-    inputs[9] = vm.toString(voter);
+    inputs[1] = '@bgd-labs/aave-cli@0.1.0';
+    inputs[2] = 'governance';
+    inputs[3] = 'getVotingProofs';
+    inputs[4] = '--proposalId';
+    inputs[5] = vm.toString(proposalId);
+    inputs[6] = '--voter';
+    inputs[7] = vm.toString(voter);
     Vm.FfiResult memory f = vm.tryFfi(inputs);
     if (f.exitCode != 0) {
       console2.logString(string(f.stderr));
@@ -117,15 +115,13 @@ library GovV3Helpers {
     Vm vm,
     uint256 proposalId
   ) internal returns (StorageRootResponse[] memory) {
-    string[] memory inputs = new string[](8);
+    string[] memory inputs = new string[](6);
     inputs[0] = 'npx';
-    inputs[1] = '--yes';
-    inputs[2] = '-s';
-    inputs[3] = '@bgd-labs/aave-cli@0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0';
-    inputs[4] = 'governance';
-    inputs[5] = 'getStorageRoots';
-    inputs[6] = '--proposalId';
-    inputs[7] = vm.toString(proposalId);
+    inputs[1] = '@bgd-labs/aave-cli@0.1.0';
+    inputs[2] = 'governance';
+    inputs[3] = 'getStorageRoots';
+    inputs[4] = '--proposalId';
+    inputs[5] = vm.toString(proposalId);
     Vm.FfiResult memory f = vm.tryFfi(inputs);
     if (f.exitCode != 0) {
       console2.logString(string(f.stderr));

--- a/src/IpfsUtils.sol
+++ b/src/IpfsUtils.sol
@@ -7,15 +7,13 @@ library IpfsUtils {
   error FfiFailed();
 
   function ipfsHashFile(Vm vm, string memory filePath, bool upload) internal returns (bytes32) {
-    string[] memory inputs = new string[](7);
+    string[] memory inputs = new string[](5);
     inputs[0] = 'npx';
-    inputs[1] = '--yes';
-    inputs[2] = '-s';
-    inputs[3] = '@bgd-labs/aave-cli@0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0';
-    inputs[4] = 'ipfs';
-    inputs[5] = filePath;
+    inputs[1] = '@bgd-labs/aave-cli@0.1.0';
+    inputs[2] = 'ipfs';
+    inputs[3] = filePath;
     if (upload) {
-      inputs[6] = '-u';
+      inputs[4] = '-u';
     }
     Vm.FfiResult memory f = vm.tryFfi(inputs);
     if (f.exitCode != 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,22 +34,22 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@bgd-labs/aave-address-book@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-address-book/-/aave-address-book-2.7.0.tgz#ae26abb1a340fe795b9a2febd87f842c2ed06a99"
-  integrity sha512-TYErogNQIecHnnr7NXxGSnr1d/QuXNP9o5L8wRzx0+GIJiCi7Dmy9dlJxQO/nEky/Nq512l09xYKjRVnTz37Tg==
+"@bgd-labs/aave-address-book@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-address-book/-/aave-address-book-2.10.0.tgz#19873ec0edf9ee1f1a5539162e6092b0a2b2c4b4"
+  integrity sha512-DVglkDCYUf7etb6mnCziIY2HPgap4X3AnC/1tC0ZqpXFrhO0lQzWBiMeWy20r1x/b81iHMQa02ULaco3LhdeVw==
 
-"@bgd-labs/aave-cli@0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0":
-  version "0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0"
-  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-cli/-/aave-cli-0.0.27-0a01f2a07efe0ec4c875cf479004d20350235f64.0.tgz#2e3d4de157aae111af294d236536fdca0a51150e"
-  integrity sha512-7JI0j7JBkXoqmvEneBd0s9GFZuUoiTWFc+vrErWl/xvm3HbyaxO4t3NwpPata5zeVVLO9bBijRGCKJ1ZZwtCwg==
+"@bgd-labs/aave-cli@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@bgd-labs/aave-cli/-/aave-cli-0.1.0.tgz#f10a23735173387d92a802b19abf3ad8987c0104"
+  integrity sha512-CDU4VSp51+NaDvGNw/Gax4fMMIMTGm0CN54vFifiKC3QTM/ZCCY614Gca1UEBt5cOvOxHe2OmGYqgeoZ3s8BlA==
   dependencies:
-    "@bgd-labs/aave-address-book" "2.7.0"
+    "@bgd-labs/aave-address-book" "2.10.0"
     "@commander-js/extra-typings" "^11.1.0"
-    "@inquirer/prompts" "^3.2.0"
+    "@inquirer/prompts" "^3.3.0"
     bs58 "^5.0.0"
     chalk "^4.1.2"
-    commander "^11.0.0"
+    commander "^11.1.0"
     deepmerge "^4.3.1"
     dotenv "^16.3.1"
     gray-matter "^4.0.3"
@@ -57,7 +57,7 @@
     json-bigint "^1.0.0"
     node-fetch "^2.6.9"
     object-hash "^3.0.0"
-    viem "^1.16.6"
+    viem "^1.18.9"
     zod "^3.22.4"
 
 "@commander-js/extra-typings@^11.1.0":
@@ -65,34 +65,34 @@
   resolved "https://registry.yarnpkg.com/@commander-js/extra-typings/-/extra-typings-11.1.0.tgz#dd19fcb8cc6e33ede237fc1b7af96c70833d8f93"
   integrity sha512-GuvZ38d23H+7Tz2C9DhzCepivsOsky03s5NI+KCy7ke1FNUvsJ2oO47scQ9YaGGhgjgNW5OYYNSADmbjcSoIhw==
 
-"@inquirer/checkbox@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-1.4.0.tgz#9e583188be55f22ed624d2829421a3354d3d8c1a"
-  integrity sha512-7YcekwCvMTjrgjUursrH6AGZUSPw7gKPMvp0VhM3iq9mL46a7AeCfOTQTW0UPeiIfWmZK8wHyAD6wIhfDyLHpw==
+"@inquirer/checkbox@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-1.5.0.tgz#05869b4ee81e2c8d523799ef350d57cabd556bfa"
+  integrity sha512-3cKJkW1vIZAs4NaS0reFsnpAjP0azffYII4I2R7PTI7ZTMg5Y1at4vzXccOH3762b2c2L4drBhpJpf9uiaGNxA==
   dependencies:
-    "@inquirer/core" "^5.1.0"
+    "@inquirer/core" "^5.1.1"
     "@inquirer/type" "^1.1.5"
     ansi-escapes "^4.3.2"
     chalk "^4.1.2"
     figures "^3.2.0"
 
-"@inquirer/confirm@^2.0.14":
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-2.0.14.tgz#b87fcdf218d0ce687bd021623e091d3a80744e9e"
-  integrity sha512-Elzo5VX5lO1q9xy8CChDtDQNVLaucufdZBAM12qdfX1L3NQ+TypnZytGmWDXHBTpBTwuhEuwxNvUw7B0HCURkw==
+"@inquirer/confirm@^2.0.15":
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-2.0.15.tgz#b5512ed190efd8c5b96e0969115756b48546ab36"
+  integrity sha512-hj8Q/z7sQXsF0DSpLQZVDhWYGN6KLM/gNjjqGkpKwBzljbQofGjn0ueHADy4HUY+OqDHmXuwk/bY+tZyIuuB0w==
   dependencies:
-    "@inquirer/core" "^5.1.0"
+    "@inquirer/core" "^5.1.1"
     "@inquirer/type" "^1.1.5"
     chalk "^4.1.2"
 
-"@inquirer/core@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-5.1.0.tgz#2e3f6abf1dee93eae60cd85a5168c52400f73c9c"
-  integrity sha512-EVnific72BhMOMo8mElvrYhGFWJZ73X6j0I+fITIPTsdAz6Z9A3w3csKy+XaH87/5QAEIQHR7RSCVXvQpIqNdQ==
+"@inquirer/core@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-5.1.1.tgz#849d4846aea68371c133df6ec9059f5e5bd30d30"
+  integrity sha512-IuJyZQUg75+L5AmopgnzxYrgcU6PJKL0hoIs332G1Gv55CnmZrhG6BzNOeZ5sOsTi1YCGOopw4rYICv74ejMFg==
   dependencies:
     "@inquirer/type" "^1.1.5"
-    "@types/mute-stream" "^0.0.2"
-    "@types/node" "^20.8.2"
+    "@types/mute-stream" "^0.0.4"
+    "@types/node" "^20.9.0"
     "@types/wrap-ansi" "^3.0.0"
     ansi-escapes "^4.3.2"
     chalk "^4.1.2"
@@ -105,75 +105,75 @@
     strip-ansi "^6.0.1"
     wrap-ansi "^6.2.0"
 
-"@inquirer/editor@^1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-1.2.12.tgz#3dfa72253e8a9d915b43f3c8dbc8df85e3c627ff"
-  integrity sha512-Y7zXQqcglPbbPkx0DPwx6HQFstJR5uex4hoQprjpdxSj8+Bf04+Og6mK/FNxoQbPvoNecegtmMGxDC+hVcMJZA==
+"@inquirer/editor@^1.2.13":
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-1.2.13.tgz#94bddeeabc043d4a05fbde8523add4db221555d5"
+  integrity sha512-gBxjqt0B9GLN0j6M/tkEcmcIvB2fo9Cw0f5NRqDTkYyB9AaCzj7qvgG0onQ3GVPbMyMbbP4tWYxrBOaOdKpzNA==
   dependencies:
-    "@inquirer/core" "^5.1.0"
+    "@inquirer/core" "^5.1.1"
     "@inquirer/type" "^1.1.5"
     chalk "^4.1.2"
     external-editor "^3.1.0"
 
-"@inquirer/expand@^1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-1.1.13.tgz#921d36274c0b143f7bf6cefb42f002be9cd1646f"
-  integrity sha512-/+7CGCa7iyJIpli0NtukEAjSI7+wGgjYzsByLVSSAk3U696ZlCCP6iPtsWx6d1qfmaMmCzejcjylOj6OAeu4bA==
+"@inquirer/expand@^1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-1.1.14.tgz#d315014939d0bb82ed2b769907db5bd1922fb823"
+  integrity sha512-yS6fJ8jZYAsxdxuw2c8XTFMTvMR1NxZAw3LxDaFnqh7BZ++wTQ6rSp/2gGJhMacdZ85osb+tHxjVgx7F+ilv5g==
   dependencies:
-    "@inquirer/core" "^5.1.0"
+    "@inquirer/core" "^5.1.1"
     "@inquirer/type" "^1.1.5"
     chalk "^4.1.2"
     figures "^3.2.0"
 
-"@inquirer/input@^1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-1.2.13.tgz#27ee5826e2988735a78f50510c9652d2ef29e39a"
-  integrity sha512-gALuvSpZRYfqygPjlYWodMZ4TXwALvw7Pk4tRFhE1oMN79rLVlg88Z/X6JCUh+uV2qLaxxgbeP+cgPWTvuWsCg==
+"@inquirer/input@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-1.2.14.tgz#8951867618bb5cd16dd096e02404eec225a92207"
+  integrity sha512-tISLGpUKXixIQue7jypNEShrdzJoLvEvZOJ4QRsw5XTfrIYfoWFqAjMQLerGs9CzR86yAI89JR6snHmKwnNddw==
   dependencies:
-    "@inquirer/core" "^5.1.0"
+    "@inquirer/core" "^5.1.1"
     "@inquirer/type" "^1.1.5"
     chalk "^4.1.2"
 
-"@inquirer/password@^1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-1.1.13.tgz#b7f0a0f7feed90e01630a9df4a14eab09697fcd6"
-  integrity sha512-6STGbL4Vm6ohE2yDBOSENCpCeywnvPux5psZVpvblGDop1oPiZkdsVI+NhsA0c4BE6YT0fNVK8Oqxf5Dgt5k7g==
+"@inquirer/password@^1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-1.1.14.tgz#c1fc139efe84a38986870a1bcf80718050f82bbf"
+  integrity sha512-vL2BFxfMo8EvuGuZYlryiyAB3XsgtbxOcFs4H9WI9szAS/VZCAwdVqs8rqEeaAf/GV/eZOghIOYxvD91IsRWSg==
   dependencies:
-    "@inquirer/input" "^1.2.13"
+    "@inquirer/input" "^1.2.14"
     "@inquirer/type" "^1.1.5"
     ansi-escapes "^4.3.2"
     chalk "^4.1.2"
 
-"@inquirer/prompts@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-3.2.0.tgz#8f4feaa81560d22e77b55c676e9296a108daf5b1"
-  integrity sha512-sfT7eDoveChXr8iIfwUYkoVBjUcKqXluhjM0EVhRhN59ZuJCc5DAdnuKwaFXomwESDoN0f+2zHy+MpxUg+EZuQ==
+"@inquirer/prompts@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-3.3.0.tgz#1324881d207e37b1162f174fb9726b9ecb4c475c"
+  integrity sha512-BBCqdSnhNs+WziSIo4f/RNDu6HAj4R/Q5nMgJb5MNPFX8sJGCvj9BoALdmR0HTWXyDS7TO8euKj6W6vtqCQG7A==
   dependencies:
-    "@inquirer/checkbox" "^1.4.0"
-    "@inquirer/confirm" "^2.0.14"
-    "@inquirer/core" "^5.1.0"
-    "@inquirer/editor" "^1.2.12"
-    "@inquirer/expand" "^1.1.13"
-    "@inquirer/input" "^1.2.13"
-    "@inquirer/password" "^1.1.13"
-    "@inquirer/rawlist" "^1.2.13"
-    "@inquirer/select" "^1.3.0"
+    "@inquirer/checkbox" "^1.5.0"
+    "@inquirer/confirm" "^2.0.15"
+    "@inquirer/core" "^5.1.1"
+    "@inquirer/editor" "^1.2.13"
+    "@inquirer/expand" "^1.1.14"
+    "@inquirer/input" "^1.2.14"
+    "@inquirer/password" "^1.1.14"
+    "@inquirer/rawlist" "^1.2.14"
+    "@inquirer/select" "^1.3.1"
 
-"@inquirer/rawlist@^1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-1.2.13.tgz#e74f003d417add415fea8c349d186eef7cda5032"
-  integrity sha512-f+bASrCY2x2F90MrBYX7nUSetL6FsVLfskhGWEyVwj6VIXzc9T878z3v7KU3V10D1trWrCVHOdeqEcbnO68yhg==
+"@inquirer/rawlist@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-1.2.14.tgz#7fac491345a984bafad96817a4f5ae45fb6b0c96"
+  integrity sha512-xIYmDpYgfz2XGCKubSDLKEvadkIZAKbehHdWF082AyC2I4eHK44RUfXaoOAqnbqItZq4KHXS6jDJ78F2BmQvxg==
   dependencies:
-    "@inquirer/core" "^5.1.0"
+    "@inquirer/core" "^5.1.1"
     "@inquirer/type" "^1.1.5"
     chalk "^4.1.2"
 
-"@inquirer/select@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-1.3.0.tgz#00dfa5068bea85bffeb7aa7c402407bb590c8cd4"
-  integrity sha512-3sL5odCDYI+i+piAFqFa5ULDUKEpc0U1zEY4Wm6gjP6nMAHWM8r1UzMlpQXCyHny91Tz+oeSLeKinAde0z6R7w==
+"@inquirer/select@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-1.3.1.tgz#b10bb8d4ba72f08eb887b3d948eb734d680897c6"
+  integrity sha512-EgOPHv7XOHEqiBwBJTyiMg9r57ySyW4oyYCumGp+pGyOaXQaLb2kTnccWI6NFd9HSi5kDJhF7YjA+3RfMQJ2JQ==
   dependencies:
-    "@inquirer/core" "^5.1.0"
+    "@inquirer/core" "^5.1.1"
     "@inquirer/type" "^1.1.5"
     ansi-escapes "^4.3.2"
     chalk "^4.1.2"
@@ -289,28 +289,28 @@
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/minimist@^1.2.0":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.4.tgz#81f886786411c45bba3f33e781ab48bd56bfca2e"
-  integrity sha512-Kfe/D3hxHTusnPNRbycJE1N77WHDsdS4AjUYIzlDzhDrS47NrwuL3YW4VITxwR7KCVpzwgy4Rbj829KSSQmwXQ==
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
+  integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
 
-"@types/mute-stream@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@types/mute-stream/-/mute-stream-0.0.2.tgz#5a011b17307364e48591ac6829a8e40e1c10c6b0"
-  integrity sha512-FpiGjk6+IOrN0lZEfUUjdra1csU1VxwYFj4S0Zj+TJpu5x5mZW30RkEZojTadrNZHNmpCHgoE62IQZAH0OeuIA==
+"@types/mute-stream@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mute-stream/-/mute-stream-0.0.4.tgz#77208e56a08767af6c5e1237be8888e2f255c478"
+  integrity sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@^20.8.2":
-  version "20.8.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
-  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^20.9.0":
+  version "20.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.0.tgz#bfcdc230583aeb891cf51e73cfdaacdd8deae298"
+  integrity sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==
   dependencies:
     undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.3.tgz#291c243e4b94dbfbc0c0ee26b7666f1d5c030e2c"
-  integrity sha512-ehPtgRgaULsFG8x0NeYJvmyH1hmlfsNLujHe9dQEia/7MAJYdzMSi19JtchUHjmBA6XC/75dK55mzZH+RyieSg==
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
+  integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
 "@types/wrap-ansi@^3.0.0":
   version "3.0.0"
@@ -489,7 +489,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-commander@^11.0.0:
+commander@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
@@ -1344,10 +1344,10 @@ varint@^6.0.0:
   resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
   integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
 
-viem@^1.16.6:
-  version "1.18.6"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-1.18.6.tgz#301d0d9ddd4704cba422d943f06776134ae341ec"
-  integrity sha512-oKkrxF2aqxjJ4pmm0ko7j+ZFRekP6VGIknSroV+6+dF+T31bscltPZwJ0fOJDxCOVhoVtxrKFRTkkasEVDblUA==
+viem@^1.18.9:
+  version "1.18.9"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-1.18.9.tgz#8be8fe3148b1c6c3bccc853001df98f91a8aeb30"
+  integrity sha512-eAXtoTwAFA3YEgjTYMb5ZTQrDC0UPx5qyZ4sv90TirVKepcM9mBPksTkC1SSWya0UdxhBmhEBL/CiYMjmGCTWg==
   dependencies:
     "@adraffy/ens-normalize" "1.9.4"
     "@noble/curves" "1.2.0"


### PR DESCRIPTION
reverts #133 (@hexonaut, not sure if still relevant for you)

Calling `npx package --yes` concurrently might lead to globally broken node_module installations.
The reason is that npx is not concurrency safe by design: https://github.com/npm/cli/issues/6955#issuecomment-1799527865

With this patch applied the cli will assume a local install of the package in order to work.