### PR TITLE
Allow setting borrow caps while paused if there is no cap set yet.

### DIFF
--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -111,7 +111,8 @@ contract ProtocolV3TestBase is CommonTestBase {
       // if config existed before
       if (i < configsBeforeLength) {
         // borrow increase should only happen on assets with borrowing enabled
-        if (configBefore[i].borrowCap < configAfter[i].borrowCap) {
+        // unless it is setting a borrow cap for the first time
+        if (configBefore[i].borrowCap < configAfter[i].borrowCap && configBefore[i].borrowCap != 0) {
           require(configAfter[i].borrowingEnabled, 'PL_BORROW_CAP_BORROW_DISABLED');
         }
       } else {


### PR DESCRIPTION
We will use this to set initial caps on jEUR and agEUR on polygon v3 as described here https://snapshot.org/#/aave.eth/proposal/0xcab97d0cf0f484f3604f790234ca26b559b6c38c0b33ed1f7821b3d3340c9354