### PR TITLE
fix: blocknumber for tests

### DIFF
--- a/tests/v3-config-engine/AaveV3ConfigEngineTest.t.sol
+++ b/tests/v3-config-engine/AaveV3ConfigEngineTest.t.sol
@@ -40,7 +40,7 @@ contract AaveV3ConfigEngineTest is ProtocolV3TestBase {
 
   function setUp() public {
     mainnetFork = vm.createSelectFork(vm.rpcUrl('mainnet'), 18515746);
-    optimismFork = vm.createSelectFork(vm.rpcUrl('optimism'), 111854461);
+    optimismFork = vm.createSelectFork(vm.rpcUrl('optimism'), 113126927);
     polygonFork = vm.createSelectFork(vm.rpcUrl('polygon'), 50170881);
     avalancheFork = vm.createSelectFork(vm.rpcUrl('avalanche'), 37426577);
     arbitrumFork = vm.createSelectFork(vm.rpcUrl('arbitrum'), 147823152);

--- a/tests/v3-config-engine/V3RateStrategyFactory.t.sol
+++ b/tests/v3-config-engine/V3RateStrategyFactory.t.sol
@@ -12,7 +12,7 @@ contract V3RateStrategyFactoryTest is ProtocolV3TestBase {
   V3RateStrategyFactory rateStrategyFactory;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 17370731);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18726128);
     rateStrategyFactory = new V3RateStrategyFactory(AaveV3Ethereum.POOL_ADDRESSES_PROVIDER);
   }
 


### PR DESCRIPTION
The tests were failing before, as the contracts from address book got updated, and but the blocknumber was pointing to an older block where the contracts does not exist.