### PR TITLE
fix: patching usdc is no longer needed

### DIFF
--- a/diffs/preTestEngineAvaV3Gauntlet_postTestEngineAvaV3Gauntlet.md
+++ b/diffs/preTestEngineAvaV3Gauntlet_postTestEngineAvaV3Gauntlet.md
@@ -2,12 +2,12 @@
 
 ### Reserve altered
 
-#### WETH.e ([0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB](https://snowtrace.io/address/0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB))
+#### WETH.e ([0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB](https://snowscan.xyz/address/0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB))
 
 | description | value before | value after |
 | --- | --- | --- |
 | reserveFactor | 10 % | 15 % |
-| interestRateStrategy | [0x79a906e8c998d2fb5C5D66d23c4c5416Fe0168D6](https://snowtrace.io/address/0x79a906e8c998d2fb5C5D66d23c4c5416Fe0168D6) | [0xc76EF342898f1AE7E6C4632627Df683FAD8563DD](https://snowtrace.io/address/0xc76EF342898f1AE7E6C4632627Df683FAD8563DD) |
+| interestRateStrategy | [0x79a906e8c998d2fb5C5D66d23c4c5416Fe0168D6](https://snowscan.xyz/address/0x79a906e8c998d2fb5C5D66d23c4c5416Fe0168D6) | [0xc76EF342898f1AE7E6C4632627Df683FAD8563DD](https://snowscan.xyz/address/0xc76EF342898f1AE7E6C4632627Df683FAD8563DD) |
 | stableRateSlope1 | 0 % | 4 % |
 | optimalUsageRatio | 45 % | 80 % |
 | maxExcessUsageRatio | 55 % | 20 % |
@@ -18,34 +18,34 @@
 | stableRateSlope2 | 0 % | 80 % |
 | interestRate | ![before](/.assets/be291dc02d59fb42923f19f29caa401129501a47.svg) | ![after](/.assets/2bed3d1cc40e3ecced7768caf9f6695c5217d96f.svg) |
 
-#### MAI ([0x5c49b268c9841AFF1Cc3B0a418ff5c3442eE3F3b](https://snowtrace.io/address/0x5c49b268c9841AFF1Cc3B0a418ff5c3442eE3F3b))
+#### MAI ([0x5c49b268c9841AFF1Cc3B0a418ff5c3442eE3F3b](https://snowscan.xyz/address/0x5c49b268c9841AFF1Cc3B0a418ff5c3442eE3F3b))
 
 | description | value before | value after |
 | --- | --- | --- |
 | reserveFactor | 10 % | 20 % |
-| interestRateStrategy | [0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82](https://snowtrace.io/address/0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82) | [0xfab05a6aF585da2F96e21452F91E812452996BD3](https://snowtrace.io/address/0xfab05a6aF585da2F96e21452F91E812452996BD3) |
+| interestRateStrategy | [0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82](https://snowscan.xyz/address/0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82) | [0xfab05a6aF585da2F96e21452F91E812452996BD3](https://snowscan.xyz/address/0xfab05a6aF585da2F96e21452F91E812452996BD3) |
 | variableRateSlope2 | 60 % | 75 % |
 | stableRateSlope2 | 60 % | 75 % |
 | optimalUsageRatio | 90 % | 80 % |
 | maxExcessUsageRatio | 10 % | 20 % |
 | interestRate | ![before](/.assets/24aea288aafbdead424aa0c4d79f42141f457a50.svg) | ![after](/.assets/b075925b933e4a9a254e5b3a21a83a6eae64a797.svg) |
 
-#### USDt ([0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7](https://snowtrace.io/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7))
+#### USDt ([0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7](https://snowscan.xyz/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7))
 
 | description | value before | value after |
 | --- | --- | --- |
-| interestRateStrategy | [0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82](https://snowtrace.io/address/0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82) | [0xfab05a6aF585da2F96e21452F91E812452996BD3](https://snowtrace.io/address/0xfab05a6aF585da2F96e21452F91E812452996BD3) |
+| interestRateStrategy | [0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82](https://snowscan.xyz/address/0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82) | [0xfab05a6aF585da2F96e21452F91E812452996BD3](https://snowscan.xyz/address/0xfab05a6aF585da2F96e21452F91E812452996BD3) |
 | variableRateSlope2 | 60 % | 75 % |
 | stableRateSlope2 | 60 % | 75 % |
 | optimalUsageRatio | 90 % | 80 % |
 | maxExcessUsageRatio | 10 % | 20 % |
 | interestRate | ![before](/.assets/24aea288aafbdead424aa0c4d79f42141f457a50.svg) | ![after](/.assets/b075925b933e4a9a254e5b3a21a83a6eae64a797.svg) |
 
-#### FRAX ([0xD24C2Ad096400B6FBcd2ad8B24E7acBc21A1da64](https://snowtrace.io/address/0xD24C2Ad096400B6FBcd2ad8B24E7acBc21A1da64))
+#### FRAX ([0xD24C2Ad096400B6FBcd2ad8B24E7acBc21A1da64](https://snowscan.xyz/address/0xD24C2Ad096400B6FBcd2ad8B24E7acBc21A1da64))
 
 | description | value before | value after |
 | --- | --- | --- |
-| interestRateStrategy | [0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82](https://snowtrace.io/address/0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82) | [0xfab05a6aF585da2F96e21452F91E812452996BD3](https://snowtrace.io/address/0xfab05a6aF585da2F96e21452F91E812452996BD3) |
+| interestRateStrategy | [0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82](https://snowscan.xyz/address/0xf4a0039F2d4a2EaD5216AbB6Ae4C4C3AA2dB9b82) | [0xfab05a6aF585da2F96e21452F91E812452996BD3](https://snowscan.xyz/address/0xfab05a6aF585da2F96e21452F91E812452996BD3) |
 | variableRateSlope2 | 60 % | 75 % |
 | stableRateSlope2 | 60 % | 75 % |
 | optimalUsageRatio | 90 % | 80 % |

--- a/diffs/preTestEngineCollateralEdgeBonus_postTestEngineCollateralEdgeBonus.md
+++ b/diffs/preTestEngineCollateralEdgeBonus_postTestEngineCollateralEdgeBonus.md
@@ -2,7 +2,7 @@
 
 ### Reserves altered
 
-#### AAVE.e ([0x63a72806098Bd3D9520cC43356dD78afe5D386D9](https://snowtrace.io/address/0x63a72806098Bd3D9520cC43356dD78afe5D386D9))
+#### AAVE.e ([0x63a72806098Bd3D9520cC43356dD78afe5D386D9](https://snowscan.xyz/address/0x63a72806098Bd3D9520cC43356dD78afe5D386D9))
 
 | description | value before | value after |
 | --- | --- | --- |

--- a/diffs/preTestEngineCollateral_postTestEngineCollateral.md
+++ b/diffs/preTestEngineCollateral_postTestEngineCollateral.md
@@ -2,7 +2,7 @@
 
 ### Reserves altered
 
-#### AAVE.e ([0x63a72806098Bd3D9520cC43356dD78afe5D386D9](https://snowtrace.io/address/0x63a72806098Bd3D9520cC43356dD78afe5D386D9))
+#### AAVE.e ([0x63a72806098Bd3D9520cC43356dD78afe5D386D9](https://snowscan.xyz/address/0x63a72806098Bd3D9520cC43356dD78afe5D386D9))
 
 | description | value before | value after |
 | --- | --- | --- |

--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -86,11 +86,6 @@ contract CommonTestBase is Test {
         IERC20(asset).transfer(user, amount);
         return true;
       }
-      if (asset == AaveV3EthereumAssets.USDC_UNDERLYING) {
-        vm.prank(0xcEe284F754E854890e311e3280b767F80797180d);
-        IERC20(asset).transfer(user, amount);
-        return true;
-      }
     }
     if (block.chainid == ChainIds.OPTIMISM) {
       // sUSD
@@ -99,43 +94,10 @@ contract CommonTestBase is Test {
         IERC20(asset).transfer(user, amount);
         return true;
       }
-      if (asset == AaveV3OptimismAssets.USDCn_UNDERLYING) {
-        vm.prank(0xf491d040110384DBcf7F241fFE2A546513fD873d);
-        IERC20(asset).transfer(user, amount);
-        return true;
-      }
     }
     if (block.chainid == ChainIds.GNOSIS) {
       if (asset == AaveV3GnosisAssets.EURe_UNDERLYING) {
         vm.prank(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
-        IERC20(asset).transfer(user, amount);
-        return true;
-      }
-    }
-    if (block.chainid == ChainIds.POLYGON) {
-      if (asset == AaveV3PolygonAssets.USDCn_UNDERLYING) {
-        vm.prank(0xe7804c37c13166fF0b37F5aE0BB07A3aEbb6e245);
-        IERC20(asset).transfer(user, amount);
-        return true;
-      }
-    }
-    if (block.chainid == ChainIds.ARBITRUM) {
-      if (asset == AaveV3ArbitrumAssets.USDCn_UNDERLYING) {
-        vm.prank(0x47c031236e19d024b42f8AE6780E44A573170703);
-        IERC20(asset).transfer(user, amount);
-        return true;
-      }
-    }
-    if (block.chainid == ChainIds.AVALANCHE) {
-      if (asset == AaveV3AvalancheAssets.USDC_UNDERLYING) {
-        vm.prank(0x9f8c163cBA728e99993ABe7495F06c0A3c8Ac8b9);
-        IERC20(asset).transfer(user, amount);
-        return true;
-      }
-    }
-    if (block.chainid == ChainIds.BASE) {
-      if (asset == AaveV3BaseAssets.USDC_UNDERLYING) {
-        vm.prank(0x20FE51A9229EEf2cF8Ad9E89d91CAb9312cF3b7A);
         IERC20(asset).transfer(user, amount);
         return true;
       }

--- a/tests/CommonTestBase.t.sol
+++ b/tests/CommonTestBase.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.0;
 
 import 'forge-std/Test.sol';
-import {CommonTestBase} from '../src/CommonTestBase.sol';
-import {AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {CommonTestBase, StdDealPatch} from '../src/CommonTestBase.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 
 contract CommonTestBaseTest is CommonTestBase {
   function setUp() public {
@@ -16,7 +16,21 @@ contract CommonTestBaseTest is CommonTestBase {
 
   function test_deal2_shouldMaintainCurrentCaller() public {
     assertEq(this.call(), address(this));
-    deal2(AaveV2EthereumAssets.USDC_UNDERLYING, address(this), 100e6);
+    deal2(AaveV3EthereumAssets.USDC_UNDERLYING, address(this), 100e6);
     assertEq(this.call(), address(this));
+  }
+}
+
+contract DealMainnetTest is Test {
+  function setUp() public {
+    vm.createSelectFork('mainnet', 19467834);
+  }
+
+  function test_fxs() public {
+    StdDealPatch.deal(vm, AaveV3EthereumAssets.FXS_UNDERLYING, address(this), 1e18);
+  }
+
+  function test_ldo() public {
+    StdDealPatch.deal(vm, AaveV3EthereumAssets.LDO_UNDERLYING, address(this), 1e18);
   }
 }


### PR DESCRIPTION
https://github.com/foundry-rs/forge-std/pull/505

Some more assets like AAVE and sUSD i think are now supported, but need to be manually enabled, so left them be for now.