### PR TITLE
feat: more useful withdraw

### DIFF
--- a/src/CollectorUtils.sol
+++ b/src/CollectorUtils.sol
@@ -86,7 +86,7 @@ library CollectorUtils {
   }
 
   /**
-   * @notice Withdraw funds of the collector from the Aave v3 to the collector
+   * @notice Withdraw funds of the collector from the Aave v3 to the receiver
    * @dev due to imprecision may get 1-2 wei less then specified amount
    * @param collector aave collector
    * @param receiver receiver of the underlying
@@ -104,7 +104,7 @@ library CollectorUtils {
   }
 
   /**
-   * @notice Withdraw funds of the collector from the Aave v2 to the collector
+   * @notice Withdraw funds of the collector from the Aave v2 to the receiver
    * @dev due to imprecision may get 1-2 wei less then specified amount
    * @param collector aave collector
    * @param receiver receiver of the underlying

--- a/src/CollectorUtils.sol
+++ b/src/CollectorUtils.sol
@@ -86,29 +86,39 @@ library CollectorUtils {
   }
 
   /**
-   * @notice Withdraw funds of the collector from the Aave v3
+   * @notice Withdraw funds of the collector from the Aave v3 to the collector
    * @dev due to imprecision may get 1-2 wei less then specified amount
    * @param collector aave collector
+   * @param receiver receiver of the underlying
    * @param input withdraw parameters wrapped as IOInput
    */
-  function withdrawFromV3(ICollector collector, IOInput memory input) internal returns (uint256) {
+  function withdrawFromV3(
+    ICollector collector,
+    IOInput memory input,
+    address receiver
+  ) internal returns (uint256) {
     DataTypes.ReserveDataLegacy memory reserveData = IPool(input.pool).getReserveData(
       input.underlying
     );
-    return __withdraw(collector, input, reserveData.aTokenAddress);
+    return __withdraw(collector, input, reserveData.aTokenAddress, receiver);
   }
 
   /**
-   * @notice Withdraw funds of the collector from the Aave v2
+   * @notice Withdraw funds of the collector from the Aave v2 to the collector
    * @dev due to imprecision may get 1-2 wei less then specified amount
    * @param collector aave collector
+   * @param receiver receiver of the underlying
    * @param input withdraw parameters wrapped as IOInput
    */
-  function withdrawFromV2(ICollector collector, IOInput memory input) internal returns (uint256) {
+  function withdrawFromV2(
+    ICollector collector,
+    IOInput memory input,
+    address receiver
+  ) internal returns (uint256) {
     V2DataTypes.ReserveData memory reserveData = ILendingPool(input.pool).getReserveData(
       input.underlying
     );
-    return __withdraw(collector, input, reserveData.aTokenAddress);
+    return __withdraw(collector, input, reserveData.aTokenAddress, receiver);
   }
 
   /**
@@ -183,13 +193,14 @@ library CollectorUtils {
    * @param collector aave collector
    * @param input withdraw parameters wrapped as IOInput
    * @param aTokenAddress aToken address for the corresponding reserve in the pool
-   * @param aTokenAddress aToken address for the corresponding reserve in the pool
+   * @param receiver receiver of the underlying
    * @return the actual amount of underlying withdrawn
    */
   function __withdraw(
     ICollector collector,
     IOInput memory input,
-    address aTokenAddress
+    address aTokenAddress,
+    address receiver
   ) internal returns (uint256) {
     if (input.amount == 0) {
       revert InvalidZeroAmount();
@@ -202,6 +213,6 @@ library CollectorUtils {
     input.amount = balanceAfterTransfer >= input.amount ? input.amount : balanceAfterTransfer;
 
     // @dev withdrawal interfaces of v2 and v3 is the same, so we use any
-    return IPool(input.pool).withdraw(input.underlying, input.amount, address(collector));
+    return IPool(input.pool).withdraw(input.underlying, input.amount, address(receiver));
   }
 }

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -351,7 +351,7 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, CommonTestBase {
     return configuration.getIsVirtualAccActive();
   }
 
-  function _logReserveConfig(ReserveConfig memory config) internal view {
+  function _logReserveConfig(ReserveConfig memory config) internal pure {
     console.log('Symbol ', config.symbol);
     console.log('Underlying address ', config.underlying);
     console.log('AToken address ', config.aToken);


### PR DESCRIPTION
There seems to be some flaky test unrelated to my changes in:
```
[FAIL. Reason: revert: unknown selector `0x313ce567` for HardhatConsoleCalls; counterexample: calldata=0x9e6e28b60000000000000000000000002041f755214dbc6bffa90cc0225b39da2e5c2d3c000000000000000000000000000000000000000000000000000000003656eec20000000000000000000000000000000000000000000000000000000000001e49000000000000000000000000000000000000000000636f6e736f6c652e6c6f670000000000000000000000007109709ecfa91a80626ff3989d68f67f5b1dd12e00000000000000000000000000000000000000000000000000000000000019000000000000000000000000000000000000000000000000000000000000001aa8 args=[0x2041f755214dbc6Bffa90Cc0225b39dA2e5C2d3C, 0x000000000000000000000000000000003656EEc2, 0x0000000000000000000000000000000000001e49, 0x000000000000000000636F6e736F6c652e6c6f67, 0x7109709ecFA91A80626Ff3989D68f67f5b1Dd12E, 6400, 6824]] testSwap(address,address,address,address,address,uint256,uint256) (runs: 187, μ: 76979, ~: 76979)
```

Didn't yet figure out why, but also don't really have time to dig into this right now.