### PR TITLE
✨ add a patch for deal usage on AUSD asset

### DIFF
--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -102,6 +102,14 @@ contract CommonTestBase is Test {
         return true;
       }
     }
+    if(block.chainid == ChainIds.AVALANCHE) {
+      // AUSD
+      if (asset == 0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a) {
+        vm.prank(0x2CD78aD719a8c74898c5283f5Bc70920D8A061fd);
+        IERC20(asset).transfer(user, amount);
+        return true;
+      }
+    }
     return false;
   }
 


### PR DESCRIPTION
AUSD use a specific Storage lib that makes the native foundry `deal` function not working.
This PR add a patch for this specific AUSD asset.