### PR TITLE
Fix: fixed tests of the borrowing cap in e2e default tests for the V3 version

### DIFF
--- a/diffs/default_before_default_after.md
+++ b/diffs/default_before_default_after.md
@@ -4,7 +4,7 @@
 {
   "raw": {
     "0xdabad81af85554e9ae636395611c58f7ec1aaec5": {
-      "label": null,
+      "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
       "balanceDiff": null,
       "stateDiff": {
         "0x2eaf8b7f7a84b89daf9bbcdc5eedc2697106baf3e76b29404b2bef5909c34a72": {

--- a/tests/ProtocolV3TestBase.t.sol
+++ b/tests/ProtocolV3TestBase.t.sol
@@ -26,6 +26,23 @@ contract ProtocolV3TestBaseTest is ProtocolV3TestBase {
     );
   }
 
+  function test_e2eTestWithBigTestAssetPrice() public {
+    ReserveConfig[] memory configs = _getReservesConfigs(AaveV3Optimism.POOL);
+
+    ReserveConfig memory collateralConfig = _findReserveConfig(
+      configs,
+      AaveV3PolygonAssets.WETH_UNDERLYING
+    );
+    ReserveConfig memory testAssetConfig = _findReserveConfig(
+      configs,
+      AaveV3PolygonAssets.WETH_UNDERLYING
+    );
+
+    _changeAssetPrice(AaveV3Optimism.POOL, testAssetConfig, 1000_00); // price increases to 1'000%
+
+    e2eTestAsset(AaveV3Optimism.POOL, collateralConfig, testAssetConfig);
+  }
+
   // function testSnpashot() public {
   //   this.createConfigurationSnapshot('pre-x', AaveV3Polygon.POOL);
   //   // do sth


### PR DESCRIPTION
Original issue: #398 