### PR TITLE
feat: update tooling to support multi-chain deploy

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -2,7 +2,7 @@
   "lib/aave-address-book": {
     "branch": {
       "name": "main",
-      "rev": "79e2a33c0d655ded55c31ec4509bd541dedb5ff5"
+      "rev": "a31803177d717939ba8eceba54fee069235bd9c5"
     }
   },
   "lib/forge-std": {

--- a/src/GovV3Helpers.sol
+++ b/src/GovV3Helpers.sol
@@ -262,6 +262,25 @@ library GovV3Helpers {
   }
 
   /**
+   * @notice method to deploy the payload contracts and register them on payloads controller for a given network
+   * @param chainId the chain id for the network where payload will be deployed and registered
+   * @param payloadBytecode list of payload creation bytecode which will be deployed and registered
+   */
+  function deployRegisterPayload(Vm vm, uint256 chainId, bytes[] memory payloadBytecode) internal {
+    ChainHelpers.selectChain(vm, chainId);
+    vm.startBroadcast();
+
+    IPayloadsControllerCore.ExecutionAction[] memory actions = new IPayloadsControllerCore.ExecutionAction[](payloadBytecode.length);
+    for (uint256 i = 0; i < payloadBytecode.length; i++) {
+      address payload = deployDeterministic(payloadBytecode[i]);
+      actions[i] = buildAction(payload);
+    }
+
+    createPayload(actions);
+    vm.stopBroadcast();
+  }
+
+  /**
    * @dev builds a action to be registered on a payloadsController
    * - assumes accesscontrol level 1
    * - assumes delegateCall true

--- a/src/GovV3Helpers.sol
+++ b/src/GovV3Helpers.sol
@@ -402,7 +402,7 @@ library GovV3Helpers {
       revert PayloadAlreadyCreated();
     } else {
       for (uint256 i = 0; i < actions.length; i++) {
-        require(actions[i].target.code.length > 0, 'Target Payload Not Deployed')
+        require(actions[i].target.code.length > 0, 'Target Payload Not Deployed');
       }
       console2.log(
         'safe: ',

--- a/src/GovV3Helpers.sol
+++ b/src/GovV3Helpers.sol
@@ -401,6 +401,9 @@ library GovV3Helpers {
     if (payloadCreated && payload.createdAt > block.timestamp - 7 days) {
       revert PayloadAlreadyCreated();
     } else {
+      for (uint256 i = 0; i < actions.length; i++) {
+        require(actions[i].target.code.length > 0, 'Target Payload Not Deployed')
+      }
       console2.log(
         'safe: ',
         IPermissionedPayloadsController(address(permissionedPayloadsController)).payloadsManager()


### PR DESCRIPTION
Adds a method `deployRegisterPayload()` to deploy and register payload on the given network. 
Used in https://github.com/bgd-labs/aave-proposals-v3/pull/890 to allow multi chain deployment for proposals.