### PR TITLE
chore: fix prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -12,5 +12,6 @@
         "printWidth": 100
       }
     }
-  ]
+  ],
+  "plugins": ["prettier-plugin-solidity"]
 }

--- a/src/GovV3Helpers.sol
+++ b/src/GovV3Helpers.sol
@@ -270,7 +270,8 @@ library GovV3Helpers {
     ChainHelpers.selectChain(vm, chainId);
     vm.startBroadcast();
 
-    IPayloadsControllerCore.ExecutionAction[] memory actions = new IPayloadsControllerCore.ExecutionAction[](payloadBytecode.length);
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](payloadBytecode.length);
     for (uint256 i = 0; i < payloadBytecode.length; i++) {
       address payload = deployDeterministic(payloadBytecode[i]);
       actions[i] = buildAction(payload);

--- a/src/ProtocolV2TestBase.sol
+++ b/src/ProtocolV2TestBase.sol
@@ -91,7 +91,7 @@ contract ProtocolV2TestBase is CommonTestBase, SeatbeltUtils, DiffUtils {
     );
 
     diffReports(beforeString, afterString);
-    if (runSeatbelt) { 
+    if (runSeatbelt) {
       generateSeatbeltReport(
         reportName,
         address(GovV3Helpers.getPayloadsController(block.chainid)),

--- a/src/v2-config-engine/AaveV2PayloadAvalanche.sol
+++ b/src/v2-config-engine/AaveV2PayloadAvalanche.sol
@@ -9,6 +9,4 @@ import './AaveV2Payload.sol';
  * @author BGD Labs
  */
 // TODO: Add rates factory address after deploying
-abstract contract AaveV2PayloadAvalanche is AaveV2Payload(IEngine(AaveV2Avalanche.CONFIG_ENGINE)) {
-
-}
+abstract contract AaveV2PayloadAvalanche is AaveV2Payload(IEngine(AaveV2Avalanche.CONFIG_ENGINE)) {}

--- a/src/v2-config-engine/AaveV2PayloadEthereum.sol
+++ b/src/v2-config-engine/AaveV2PayloadEthereum.sol
@@ -9,6 +9,4 @@ import './AaveV2Payload.sol';
  * @author BGD Labs
  */
 // TODO: Add rates factory address after deploying
-abstract contract AaveV2PayloadEthereum is AaveV2Payload(IEngine(AaveV2Ethereum.CONFIG_ENGINE)) {
-
-}
+abstract contract AaveV2PayloadEthereum is AaveV2Payload(IEngine(AaveV2Ethereum.CONFIG_ENGINE)) {}

--- a/src/v2-config-engine/AaveV2PayloadEthereumAMM.sol
+++ b/src/v2-config-engine/AaveV2PayloadEthereumAMM.sol
@@ -11,6 +11,4 @@ import './AaveV2Payload.sol';
 // TODO: Add rates factory address after deploying
 abstract contract AaveV2PayloadEthereumAMM is
   AaveV2Payload(IEngine(AaveV2EthereumAMM.CONFIG_ENGINE))
-{
-
-}
+{}

--- a/src/v2-config-engine/AaveV2PayloadPolygon.sol
+++ b/src/v2-config-engine/AaveV2PayloadPolygon.sol
@@ -9,6 +9,4 @@ import './AaveV2Payload.sol';
  * @author BGD Labs
  */
 // TODO: Add rates factory address after deploying
-abstract contract AaveV2PayloadPolygon is AaveV2Payload(IEngine(AaveV2Polygon.CONFIG_ENGINE)) {
-
-}
+abstract contract AaveV2PayloadPolygon is AaveV2Payload(IEngine(AaveV2Polygon.CONFIG_ENGINE)) {}


### PR DESCRIPTION
prettier seems to be broken atm as seems it was not running on `*.sol`. changed for minimal diff, i think we should migrate to `forge fmt` later