### PR TITLE
feat: add IRangeValidationModule events to eventDb

### DIFF
--- a/.changeset/range-validation-module-events.md
+++ b/.changeset/range-validation-module-events.md
@@ -1,0 +1,5 @@
+---
+'@aave-dao/aave-helpers-js': patch
+---
+
+Add IRangeValidationModule events (DefaultRangeConfigSet, MarketRangeConfigSet) to eventDb so that RANGE_VALIDATION_MODULE contract events are decoded in diff reports instead of showing raw topics. Also fixes a bug where formatValue crashed on decoded struct args containing BigInt values.

--- a/packages/aave-helpers-js/__tests__/protocol-diff.spec.ts
+++ b/packages/aave-helpers-js/__tests__/protocol-diff.spec.ts
@@ -2108,3 +2108,65 @@ describe('renderLogsSection - IAgentConfigurator events', () => {
     expect(result).not.toContain('topics:');
   });
 });
+
+const DEFAULT_RANGE_CONFIG_SET =
+  '0xd277e912eff2e23b18786458bede5c399d8f47442262dc054ddf0f6462b5afaf';
+const MARKET_RANGE_CONFIG_SET =
+  '0x4666070bf03e7e4884898dfcc3348243da2fda61acc197ce66d0a3da1b60d793';
+
+const RANGE_VALIDATION_MODULE = '0xd24790E75799968CE3feD6E27285baD0a26e7e36';
+const AGENT_HUB_PADDED =
+  '0x00000000000000000000000017781ba226b359e5c1e1ee5ac9e28ec5b84fd039';
+// ABI-encoded RangeConfig(maxIncrease=3000, maxDecrease=3000, isIncreaseRelative=false, isDecreaseRelative=false)
+const RANGE_CONFIG_DATA =
+  '0x' +
+  '0000000000000000000000000000000000000000000000000000000000000bb8' + // maxIncrease = 3000
+  '0000000000000000000000000000000000000000000000000000000000000bb8' + // maxDecrease = 3000
+  '0000000000000000000000000000000000000000000000000000000000000000' + // isIncreaseRelative = false
+  '0000000000000000000000000000000000000000000000000000000000000000'; // isDecreaseRelative = false
+
+// ABI-encoded (string updateType, RangeConfig config) for MarketRangeConfigSet
+// RangeConfig is a static tuple, so its fields are encoded inline in the head.
+// Head: [offset_to_string(5*32=160), maxIncrease, maxDecrease, isIncreaseRelative, isDecreaseRelative]
+// Tail: [string_length, string_data]
+const MARKET_RANGE_CONFIG_DATA =
+  '0x' +
+  '00000000000000000000000000000000000000000000000000000000000000a0' + // offset to string = 5*32 = 160
+  '0000000000000000000000000000000000000000000000000000000000000bb8' + // maxIncrease = 3000
+  '0000000000000000000000000000000000000000000000000000000000000bb8' + // maxDecrease = 3000
+  '0000000000000000000000000000000000000000000000000000000000000000' + // isIncreaseRelative = false
+  '0000000000000000000000000000000000000000000000000000000000000000' + // isDecreaseRelative = false
+  '0000000000000000000000000000000000000000000000000000000000000012' + // length of "RateStrategyUpdate" = 18
+  '5261746553747261746567795570646174650000000000000000000000000000'; // "RateStrategyUpdate" padded
+
+describe('renderLogsSection - IRangeValidationModule events', () => {
+  it('decodes DefaultRangeConfigSet', async () => {
+    const result = await renderLogsSection(
+      [
+        {
+          emitter: RANGE_VALIDATION_MODULE,
+          topics: [DEFAULT_RANGE_CONFIG_SET, AGENT_HUB_PADDED, AGENT_ID_0, UPDATE_TYPE_HASH],
+          data: RANGE_CONFIG_DATA,
+        },
+      ],
+      INK_CHAIN_ID
+    );
+    expect(result).toContain('DefaultRangeConfigSet(');
+    expect(result).not.toContain('topics:');
+  });
+
+  it('decodes MarketRangeConfigSet', async () => {
+    const result = await renderLogsSection(
+      [
+        {
+          emitter: RANGE_VALIDATION_MODULE,
+          topics: [MARKET_RANGE_CONFIG_SET, AGENT_HUB_PADDED, AGENT_ID_0, MARKET_ADDRESS],
+          data: MARKET_RANGE_CONFIG_DATA,
+        },
+      ],
+      INK_CHAIN_ID
+    );
+    expect(result).toContain('MarketRangeConfigSet(');
+    expect(result).not.toContain('topics:');
+  });
+});

--- a/packages/aave-helpers-js/__tests__/protocol-diff.spec.ts
+++ b/packages/aave-helpers-js/__tests__/protocol-diff.spec.ts
@@ -1827,7 +1827,8 @@ const MINIMUM_DELAY_SET = '0x272ec2b5975364e003ffa08930bbafc77472bc7fc2c2b078bf9
 const AGENT_CONTEXT_SET = '0x62628638a1817b830bc3c14382a2f4df99a461cee4408e978bb6aaaab6a1b036';
 const ALLOWED_MARKET_ADDED = '0x2fc0d54cb5ab2406eb24b175bf09b6fff1268acd21ac14c7e3422146a60bb37e';
 const ALLOWED_MARKET_REMOVED = '0x65bb60f6360137104c7b1d036ac5e53273c9da5662306bae223c1f8942a01bcd';
-const RESTRICTED_MARKET_ADDED = '0xa32f8d38bd6f79b28a99f671eafa0d6c7d9ed79a92c6fbf9433124f335b39b84';
+const RESTRICTED_MARKET_ADDED =
+  '0xa32f8d38bd6f79b28a99f671eafa0d6c7d9ed79a92c6fbf9433124f335b39b84';
 const RESTRICTED_MARKET_REMOVED =
   '0x9fdc8893bd7bb12c1431f72399b7caf70867c7c68b1da755533287dd68c4f1dc';
 const PERMISSIONED_SENDER_ADDED =
@@ -2083,16 +2084,32 @@ describe('renderLogsSection - IAgentConfigurator events', () => {
 
   it('decodes all agent hub events in a single batch', async () => {
     const logs = [
-      { emitter: AGENT_HUB, topics: [AGENT_REGISTERED, AGENT_ID_0, RISK_ORACLE, UPDATE_TYPE_HASH], data: '0x' },
+      {
+        emitter: AGENT_HUB,
+        topics: [AGENT_REGISTERED, AGENT_ID_0, RISK_ORACLE, UPDATE_TYPE_HASH],
+        data: '0x',
+      },
       { emitter: AGENT_HUB, topics: [AGENT_ADDRESS_SET, AGENT_ID_0, AGENT_ADDRESS], data: '0x' },
       { emitter: AGENT_HUB, topics: [AGENT_ADMIN_SET, AGENT_ID_0, ADMIN_ADDRESS], data: '0x' },
       { emitter: AGENT_HUB, topics: [AGENT_ENABLED_SET, AGENT_ID_0, BOOL_TRUE], data: '0x' },
-      { emitter: AGENT_HUB, topics: [AGENT_PERMISSIONED_STATUS_SET, AGENT_ID_0, BOOL_FALSE], data: '0x' },
-      { emitter: AGENT_HUB, topics: [MARKETS_FROM_AGENT_ENABLED, AGENT_ID_0, BOOL_TRUE], data: '0x' },
+      {
+        emitter: AGENT_HUB,
+        topics: [AGENT_PERMISSIONED_STATUS_SET, AGENT_ID_0, BOOL_FALSE],
+        data: '0x',
+      },
+      {
+        emitter: AGENT_HUB,
+        topics: [MARKETS_FROM_AGENT_ENABLED, AGENT_ID_0, BOOL_TRUE],
+        data: '0x',
+      },
       { emitter: AGENT_HUB, topics: [EXPIRATION_PERIOD_SET, AGENT_ID_0, VALUE_1000], data: '0x' },
       { emitter: AGENT_HUB, topics: [MINIMUM_DELAY_SET, AGENT_ID_0, VALUE_1000], data: '0x' },
       { emitter: AGENT_HUB, topics: [AGENT_CONTEXT_SET, AGENT_ID_0, CONTEXT_HASH], data: '0x' },
-      { emitter: AGENT_HUB, topics: [ALLOWED_MARKET_ADDED, AGENT_ID_0, MARKET_ADDRESS], data: '0x' },
+      {
+        emitter: AGENT_HUB,
+        topics: [ALLOWED_MARKET_ADDED, AGENT_ID_0, MARKET_ADDRESS],
+        data: '0x',
+      },
     ];
     const result = await renderLogsSection(logs, INK_CHAIN_ID);
     expect(result).toContain('AgentRegistered(');
@@ -2115,8 +2132,7 @@ const MARKET_RANGE_CONFIG_SET =
   '0x4666070bf03e7e4884898dfcc3348243da2fda61acc197ce66d0a3da1b60d793';
 
 const RANGE_VALIDATION_MODULE = '0xd24790E75799968CE3feD6E27285baD0a26e7e36';
-const AGENT_HUB_PADDED =
-  '0x00000000000000000000000017781ba226b359e5c1e1ee5ac9e28ec5b84fd039';
+const AGENT_HUB_PADDED = '0x00000000000000000000000017781ba226b359e5c1e1ee5ac9e28ec5b84fd039';
 // ABI-encoded RangeConfig(maxIncrease=3000, maxDecrease=3000, isIncreaseRelative=false, isDecreaseRelative=false)
 const RANGE_CONFIG_DATA =
   '0x' +

--- a/packages/aave-helpers-js/sections/logs.ts
+++ b/packages/aave-helpers-js/sections/logs.ts
@@ -87,6 +87,11 @@ function formatValue(v: unknown): string {
   if (typeof v === 'string') return v;
   if (typeof v === 'boolean') return String(v);
   if (Array.isArray(v)) return `[${v.map(formatValue).join(', ')}]`;
-  if (typeof v === 'object' && v !== null) return JSON.stringify(v);
+  if (typeof v === 'object' && v !== null) {
+    const entries = Object.entries(v)
+      .map(([k, val]) => `${k}: ${formatValue(val)}`)
+      .join(', ');
+    return `{${entries}}`;
+  }
   return String(v);
 }

--- a/packages/aave-helpers-js/utils/eventDb.ts
+++ b/packages/aave-helpers-js/utils/eventDb.ts
@@ -2,1394 +2,1392 @@ import type { AbiEvent } from 'viem';
 
 export const eventDb: AbiEvent[] = [
   {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'previousOwner', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'newOwner', type: 'address' },
     ],
-    "name": "OwnershipTransferred",
-    "type": "event"
+    name: 'OwnershipTransferred',
+    type: 'event',
   },
   {
-    "type": "event",
-    "name": "RoleGranted",
-    "inputs": [
+    type: 'event',
+    name: 'RoleGranted',
+    inputs: [
       {
-        "name": "role",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
+        name: 'role',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
       },
       {
-        "name": "account",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'account',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "sender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ]
+        name: 'sender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "Approval",
-    "inputs": [
+    type: 'event',
+    name: 'Approval',
+    inputs: [
       {
-        "name": "owner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'owner',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "spender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'spender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "value",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "Transfer",
-    "inputs": [
+    type: 'event',
+    name: 'Transfer',
+    inputs: [
       {
-        "name": "from",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "to",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "value",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "RegistrationRequested",
-    "inputs": [
+    type: 'event',
+    name: 'RegistrationRequested',
+    inputs: [
       {
-        "name": "hash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
+        name: 'hash',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
       },
       {
-        "name": "name",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'name',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "encryptedEmail",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
+        name: 'encryptedEmail',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
       },
       {
-        "name": "upkeepContract",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'upkeepContract',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "gasLimit",
-        "type": "uint32",
-        "indexed": false,
-        "internalType": "uint32"
+        name: 'gasLimit',
+        type: 'uint32',
+        indexed: false,
+        internalType: 'uint32',
       },
       {
-        "name": "adminAddress",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'adminAddress',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "triggerType",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
+        name: 'triggerType',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
       },
       {
-        "name": "triggerConfig",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
+        name: 'triggerConfig',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
       },
       {
-        "name": "offchainConfig",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
+        name: 'offchainConfig',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
       },
       {
-        "name": "checkData",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
+        name: 'checkData',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
       },
       {
-        "name": "amount",
-        "type": "uint96",
-        "indexed": false,
-        "internalType": "uint96"
-      }
-    ]
+        name: 'amount',
+        type: 'uint96',
+        indexed: false,
+        internalType: 'uint96',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "UpkeepRegistered",
-    "inputs": [
+    type: 'event',
+    name: 'UpkeepRegistered',
+    inputs: [
       {
-        "name": "id",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'id',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "performGas",
-        "type": "uint32",
-        "indexed": false,
-        "internalType": "uint32"
+        name: 'performGas',
+        type: 'uint32',
+        indexed: false,
+        internalType: 'uint32',
       },
       {
-        "name": "admin",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      }
-    ]
+        name: 'admin',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "UpkeepCheckDataSet",
-    "inputs": [
+    type: 'event',
+    name: 'UpkeepCheckDataSet',
+    inputs: [
       {
-        "name": "id",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'id',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "newCheckData",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'newCheckData',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "UpkeepTriggerConfigSet",
-    "inputs": [
+    type: 'event',
+    name: 'UpkeepTriggerConfigSet',
+    inputs: [
       {
-        "name": "id",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'id',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "triggerConfig",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'triggerConfig',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "UpkeepOffchainConfigSet",
-    "inputs": [
+    type: 'event',
+    name: 'UpkeepOffchainConfigSet',
+    inputs: [
       {
-        "name": "id",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'id',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "offchainConfig",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'offchainConfig',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "Transfer",
-    "inputs": [
+    type: 'event',
+    name: 'Transfer',
+    inputs: [
       {
-        "name": "from",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "to",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "value",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "data",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'data',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "FundsAdded",
-    "inputs": [
+    type: 'event',
+    name: 'FundsAdded',
+    inputs: [
       {
-        "name": "id",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'id',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "from",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint96",
-        "indexed": false,
-        "internalType": "uint96"
-      }
-    ]
+        name: 'amount',
+        type: 'uint96',
+        indexed: false,
+        internalType: 'uint96',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "RegistrationApproved",
-    "inputs": [
+    type: 'event',
+    name: 'RegistrationApproved',
+    inputs: [
       {
-        "name": "hash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
+        name: 'hash',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
       },
       {
-        "name": "displayName",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'displayName',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "upkeepId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'upkeepId',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "KeeperRegistered",
-    "inputs": [
+    type: 'event',
+    name: 'KeeperRegistered',
+    inputs: [
       {
-        "name": "id",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'id',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "upkeep",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'upkeep',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint96",
-        "indexed": true,
-        "internalType": "uint96"
-      }
-    ]
+        name: 'amount',
+        type: 'uint96',
+        indexed: true,
+        internalType: 'uint96',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "ExecutedAction",
-    "inputs": [
+    type: 'event',
+    name: 'ExecutedAction',
+    inputs: [
       {
-        "name": "target",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'target',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "value",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "signature",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'signature',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "data",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
+        name: 'data',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
       },
       {
-        "name": "executionTime",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'executionTime',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "withDelegatecall",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
+        name: 'withDelegatecall',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
       },
       {
-        "name": "resultData",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'resultData',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "PayloadExecuted",
-    "inputs": [
+    type: 'event',
+    name: 'PayloadExecuted',
+    inputs: [
       {
-        "name": "payloadId",
-        "type": "uint40",
-        "indexed": false,
-        "internalType": "uint40"
-      }
-    ]
+        name: 'payloadId',
+        type: 'uint40',
+        indexed: false,
+        internalType: 'uint40',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "Mint",
-    "inputs": [
+    type: 'event',
+    name: 'Mint',
+    inputs: [
       {
-        "name": "caller",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'caller',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "onBehalfOf",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'onBehalfOf',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "value",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "balanceIncrease",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'balanceIncrease',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'index',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "BalanceTransfer",
-    "inputs": [
+    type: 'event',
+    name: 'BalanceTransfer',
+    inputs: [
       {
-        "name": "from",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "to",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "value",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'value',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "index",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'index',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "CancelStream",
-    "inputs": [
+    type: 'event',
+    name: 'CancelStream',
+    inputs: [
       {
-        "name": "streamId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'streamId',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "sender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'sender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "recipient",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'recipient',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "senderBalance",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'senderBalance',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "recipientBalance",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'recipientBalance',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "CreateStream",
-    "inputs": [
+    type: 'event',
+    name: 'CreateStream',
+    inputs: [
       {
-        "name": "streamId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'streamId',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "sender",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'sender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "recipient",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'recipient',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "deposit",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'deposit',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "tokenAddress",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'tokenAddress',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "startTime",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'startTime',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "stopTime",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'stopTime',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "SupplyCapChanged",
-    "inputs": [
+    type: 'event',
+    name: 'SupplyCapChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldSupplyCap",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'oldSupplyCap',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "newSupplyCap",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'newSupplyCap',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "BorrowCapChanged",
-    "inputs": [
+    type: 'event',
+    name: 'BorrowCapChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldBorrowCap",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'oldBorrowCap',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "newBorrowCap",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'newBorrowCap',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "BridgeAdapterUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'BridgeAdapterUpdated',
+    inputs: [
       {
-        "name": "destinationChainId",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
+        name: 'destinationChainId',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
       },
       {
-        "name": "bridgeAdapter",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'bridgeAdapter',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "destinationBridgeAdapter",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'destinationBridgeAdapter',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "allowed",
-        "type": "bool",
-        "indexed": true,
-        "internalType": "bool"
-      }
-    ]
+        name: 'allowed',
+        type: 'bool',
+        indexed: true,
+        internalType: 'bool',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "AssetSourceUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'AssetSourceUpdated',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "source",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ]
+        name: 'source',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "Initialized",
-    "inputs": [
+    type: 'event',
+    name: 'Initialized',
+    inputs: [
       {
-        "name": "underlyingAsset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'underlyingAsset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "pool",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'pool',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "treasury",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'treasury',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "incentivesController",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'incentivesController',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "aTokenDecimals",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
+        name: 'aTokenDecimals',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
       },
       {
-        "name": "aTokenName",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'aTokenName',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "aTokenSymbol",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'aTokenSymbol',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "params",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'params',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "Initialized",
-    "inputs": [
+    type: 'event',
+    name: 'Initialized',
+    inputs: [
       {
-        "name": "underlyingAsset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'underlyingAsset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "pool",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'pool',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "incentivesController",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'incentivesController',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "debtTokenDecimals",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
+        name: 'debtTokenDecimals',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
       },
       {
-        "name": "debtTokenName",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'debtTokenName',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "debtTokenSymbol",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
+        name: 'debtTokenSymbol',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
       },
       {
-        "name": "params",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'params',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "RateDataUpdate",
-    "inputs": [
+    type: 'event',
+    name: 'RateDataUpdate',
+    inputs: [
       {
-        "name": "reserve",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'reserve',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "optimalUsageRatio",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'optimalUsageRatio',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "baseVariableBorrowRate",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'baseVariableBorrowRate',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "variableRateSlope1",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'variableRateSlope1',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "variableRateSlope2",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'variableRateSlope2',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "ReserveInitialized",
-    "inputs": [
+    type: 'event',
+    name: 'ReserveInitialized',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "aToken",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'aToken',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "stableDebtToken",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'stableDebtToken',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "variableDebtToken",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'variableDebtToken',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "interestRateStrategyAddress",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      }
-    ]
+        name: 'interestRateStrategyAddress',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "ReserveInterestRateDataChanged",
-    "inputs": [
+    type: 'event',
+    name: 'ReserveInterestRateDataChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "strategy",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'strategy',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "data",
-        "type": "bytes",
-        "indexed": false,
-        "internalType": "bytes"
-      }
-    ]
+        name: 'data',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "ReserveBorrowing",
-    "inputs": [
+    type: 'event',
+    name: 'ReserveBorrowing',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "enabled",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ]
+        name: 'enabled',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "BorrowableInIsolationChanged",
-    "inputs": [
+    type: 'event',
+    name: 'BorrowableInIsolationChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "borrowable",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ]
+        name: 'borrowable',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "SiloedBorrowingChanged",
-    "inputs": [
+    type: 'event',
+    name: 'SiloedBorrowingChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldState",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
+        name: 'oldState',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
       },
       {
-        "name": "newState",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ]
+        name: 'newState',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "ReserveFactorChanged",
-    "inputs": [
+    type: 'event',
+    name: 'ReserveFactorChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldReserveFactor",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'oldReserveFactor',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "newReserveFactor",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'newReserveFactor',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "ReserveDataUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'ReserveDataUpdated',
+    inputs: [
       {
-        "name": "reserve",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'reserve',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "liquidityRate",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'liquidityRate',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "stableBorrowRate",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'stableBorrowRate',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "variableBorrowRate",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'variableBorrowRate',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "liquidityIndex",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'liquidityIndex',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "variableBorrowIndex",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'variableBorrowIndex',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "ReserveFlashLoaning",
-    "inputs": [
+    type: 'event',
+    name: 'ReserveFlashLoaning',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "enabled",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ]
+        name: 'enabled',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "CollateralConfigurationChanged",
-    "inputs": [
+    type: 'event',
+    name: 'CollateralConfigurationChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "ltv",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'ltv',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "liquidationThreshold",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'liquidationThreshold',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "liquidationBonus",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'liquidationBonus',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "DebtCeilingChanged",
-    "inputs": [
+    type: 'event',
+    name: 'DebtCeilingChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldDebtCeiling",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'oldDebtCeiling',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "newDebtCeiling",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'newDebtCeiling',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "LiquidationProtocolFeeChanged",
-    "inputs": [
+    type: 'event',
+    name: 'LiquidationProtocolFeeChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldFee",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'oldFee',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "newFee",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ]
+        name: 'newFee',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "EModeCategoryAdded",
-    "inputs": [
+    type: 'event',
+    name: 'EModeCategoryAdded',
+    inputs: [
       {
-        "name": "categoryId",
-        "type": "uint8",
-        "indexed": true,
-        "internalType": "uint8"
+        name: 'categoryId',
+        type: 'uint8',
+        indexed: true,
+        internalType: 'uint8',
       },
       {
-        "name": "ltv",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'ltv',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "liquidationThreshold",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'liquidationThreshold',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "liquidationBonus",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'liquidationBonus',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "oracle",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'oracle',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "label",
-        "type": "string",
-        "indexed": false,
-        "internalType": "string"
-      }
-    ]
+        name: 'label',
+        type: 'string',
+        indexed: false,
+        internalType: 'string',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "AssetCollateralInEModeChanged",
-    "inputs": [
+    type: 'event',
+    name: 'AssetCollateralInEModeChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "categoryId",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
+        name: 'categoryId',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
       },
       {
-        "name": "collateral",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ]
+        name: 'collateral',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "AssetBorrowableInEModeChanged",
-    "inputs": [
+    type: 'event',
+    name: 'AssetBorrowableInEModeChanged',
+    inputs: [
       {
-        "name": "asset",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'asset',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "categoryId",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
+        name: 'categoryId',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
       },
       {
-        "name": "borrowable",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      }
-    ]
+        name: 'borrowable',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "Supply",
-    "inputs": [
+    type: 'event',
+    name: 'Supply',
+    inputs: [
       {
-        "name": "reserve",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'reserve',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "user",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
+        name: 'user',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
       },
       {
-        "name": "onBehalfOf",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'onBehalfOf',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
       },
       {
-        "name": "referralCode",
-        "type": "uint16",
-        "indexed": true,
-        "internalType": "uint16"
-      }
-    ]
+        name: 'referralCode',
+        type: 'uint16',
+        indexed: true,
+        internalType: 'uint16',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "AgentRegistered",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "riskOracle", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "updateType", "type": "string", "indexed": true, "internalType": "string" }
-    ]
+    type: 'event',
+    name: 'AgentRegistered',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'riskOracle', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'updateType', type: 'string', indexed: true, internalType: 'string' },
+    ],
   },
   {
-    "type": "event",
-    "name": "AgentAdminSet",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "admin", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'AgentAdminSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'admin', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "MaxBatchSizeSet",
-    "inputs": [
-      { "name": "maxBatchSize", "type": "uint256", "indexed": true, "internalType": "uint256" }
-    ]
+    type: 'event',
+    name: 'MaxBatchSizeSet',
+    inputs: [{ name: 'maxBatchSize', type: 'uint256', indexed: true, internalType: 'uint256' }],
   },
   {
-    "type": "event",
-    "name": "AgentAddressSet",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "agentAddress", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'AgentAddressSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'agentAddress', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "AgentPermissionedStatusSet",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "isAgentPermissioned", "type": "bool", "indexed": true, "internalType": "bool" }
-    ]
+    type: 'event',
+    name: 'AgentPermissionedStatusSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'isAgentPermissioned', type: 'bool', indexed: true, internalType: 'bool' },
+    ],
   },
   {
-    "type": "event",
-    "name": "PermissionedSenderAdded",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "sender", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'PermissionedSenderAdded',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'sender', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "PermissionedSenderRemoved",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "sender", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'PermissionedSenderRemoved',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'sender', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "AllowedMarketAdded",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "market", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'AllowedMarketAdded',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'market', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "AllowedMarketRemoved",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "market", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'AllowedMarketRemoved',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'market', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "RestrictedMarketAdded",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "market", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'RestrictedMarketAdded',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'market', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "RestrictedMarketRemoved",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "market", "type": "address", "indexed": true, "internalType": "address" }
-    ]
+    type: 'event',
+    name: 'RestrictedMarketRemoved',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'market', type: 'address', indexed: true, internalType: 'address' },
+    ],
   },
   {
-    "type": "event",
-    "name": "ExpirationPeriodSet",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "expirationPeriod", "type": "uint256", "indexed": true, "internalType": "uint256" }
-    ]
+    type: 'event',
+    name: 'ExpirationPeriodSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'expirationPeriod', type: 'uint256', indexed: true, internalType: 'uint256' },
+    ],
   },
   {
-    "type": "event",
-    "name": "AgentEnabledSet",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "enable", "type": "bool", "indexed": true, "internalType": "bool" }
-    ]
+    type: 'event',
+    name: 'AgentEnabledSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'enable', type: 'bool', indexed: true, internalType: 'bool' },
+    ],
   },
   {
-    "type": "event",
-    "name": "MinimumDelaySet",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "minimumDelay", "type": "uint256", "indexed": true, "internalType": "uint256" }
-    ]
+    type: 'event',
+    name: 'MinimumDelaySet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'minimumDelay', type: 'uint256', indexed: true, internalType: 'uint256' },
+    ],
   },
   {
-    "type": "event",
-    "name": "AgentContextSet",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "context", "type": "bytes", "indexed": true, "internalType": "bytes" }
-    ]
+    type: 'event',
+    name: 'AgentContextSet',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'context', type: 'bytes', indexed: true, internalType: 'bytes' },
+    ],
   },
   {
-    "type": "event",
-    "name": "MarketsFromAgentEnabled",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "enabled", "type": "bool", "indexed": true, "internalType": "bool" }
-    ]
+    type: 'event',
+    name: 'MarketsFromAgentEnabled',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'enabled', type: 'bool', indexed: true, internalType: 'bool' },
+    ],
   },
   {
-    "type": "event",
-    "name": "UpdateInjected",
-    "inputs": [
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "market", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "updateType", "type": "string", "indexed": true, "internalType": "string" },
-      { "name": "updateId", "type": "uint256", "indexed": false, "internalType": "uint256" },
-      { "name": "newValue", "type": "bytes", "indexed": false, "internalType": "bytes" }
-    ]
+    type: 'event',
+    name: 'UpdateInjected',
+    inputs: [
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'market', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'updateType', type: 'string', indexed: true, internalType: 'string' },
+      { name: 'updateId', type: 'uint256', indexed: false, internalType: 'uint256' },
+      { name: 'newValue', type: 'bytes', indexed: false, internalType: 'bytes' },
+    ],
   },
   {
-    "type": "event",
-    "name": "EmissionAdminUpdated",
-    "inputs": [
+    type: 'event',
+    name: 'EmissionAdminUpdated',
+    inputs: [
       {
-        "name": "reward",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'reward',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "oldAdmin",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        name: 'oldAdmin',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
       {
-        "name": "newAdmin",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      }
-    ]
+        name: 'newAdmin',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "DefaultRangeConfigSet",
-    "inputs": [
-      { "name": "agentHub", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "updateType", "type": "string", "indexed": true, "internalType": "string" },
+    type: 'event',
+    name: 'DefaultRangeConfigSet',
+    inputs: [
+      { name: 'agentHub', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'updateType', type: 'string', indexed: true, internalType: 'string' },
       {
-        "name": "config",
-        "type": "tuple",
-        "indexed": false,
-        "internalType": "struct IRangeValidationModule.RangeConfig",
-        "components": [
-          { "name": "maxIncrease", "type": "uint120", "internalType": "uint120" },
-          { "name": "maxDecrease", "type": "uint120", "internalType": "uint120" },
-          { "name": "isIncreaseRelative", "type": "bool", "internalType": "bool" },
-          { "name": "isDecreaseRelative", "type": "bool", "internalType": "bool" }
-        ]
-      }
-    ]
+        name: 'config',
+        type: 'tuple',
+        indexed: false,
+        internalType: 'struct IRangeValidationModule.RangeConfig',
+        components: [
+          { name: 'maxIncrease', type: 'uint120', internalType: 'uint120' },
+          { name: 'maxDecrease', type: 'uint120', internalType: 'uint120' },
+          { name: 'isIncreaseRelative', type: 'bool', internalType: 'bool' },
+          { name: 'isDecreaseRelative', type: 'bool', internalType: 'bool' },
+        ],
+      },
+    ],
   },
   {
-    "type": "event",
-    "name": "MarketRangeConfigSet",
-    "inputs": [
-      { "name": "agentHub", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-      { "name": "market", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "updateType", "type": "string", "indexed": false, "internalType": "string" },
+    type: 'event',
+    name: 'MarketRangeConfigSet',
+    inputs: [
+      { name: 'agentHub', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'agentId', type: 'uint256', indexed: true, internalType: 'uint256' },
+      { name: 'market', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'updateType', type: 'string', indexed: false, internalType: 'string' },
       {
-        "name": "config",
-        "type": "tuple",
-        "indexed": false,
-        "internalType": "struct IRangeValidationModule.RangeConfig",
-        "components": [
-          { "name": "maxIncrease", "type": "uint120", "internalType": "uint120" },
-          { "name": "maxDecrease", "type": "uint120", "internalType": "uint120" },
-          { "name": "isIncreaseRelative", "type": "bool", "internalType": "bool" },
-          { "name": "isDecreaseRelative", "type": "bool", "internalType": "bool" }
-        ]
-      }
-    ]
-  }
+        name: 'config',
+        type: 'tuple',
+        indexed: false,
+        internalType: 'struct IRangeValidationModule.RangeConfig',
+        components: [
+          { name: 'maxIncrease', type: 'uint120', internalType: 'uint120' },
+          { name: 'maxDecrease', type: 'uint120', internalType: 'uint120' },
+          { name: 'isIncreaseRelative', type: 'bool', internalType: 'bool' },
+          { name: 'isDecreaseRelative', type: 'bool', internalType: 'bool' },
+        ],
+      },
+    ],
+  },
 ];

--- a/packages/aave-helpers-js/utils/eventDb.ts
+++ b/packages/aave-helpers-js/utils/eventDb.ts
@@ -1348,5 +1348,48 @@ export const eventDb: AbiEvent[] = [
         "internalType": "address"
       }
     ]
+  },
+  {
+    "type": "event",
+    "name": "DefaultRangeConfigSet",
+    "inputs": [
+      { "name": "agentHub", "type": "address", "indexed": true, "internalType": "address" },
+      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
+      { "name": "updateType", "type": "string", "indexed": true, "internalType": "string" },
+      {
+        "name": "config",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IRangeValidationModule.RangeConfig",
+        "components": [
+          { "name": "maxIncrease", "type": "uint120", "internalType": "uint120" },
+          { "name": "maxDecrease", "type": "uint120", "internalType": "uint120" },
+          { "name": "isIncreaseRelative", "type": "bool", "internalType": "bool" },
+          { "name": "isDecreaseRelative", "type": "bool", "internalType": "bool" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "MarketRangeConfigSet",
+    "inputs": [
+      { "name": "agentHub", "type": "address", "indexed": true, "internalType": "address" },
+      { "name": "agentId", "type": "uint256", "indexed": true, "internalType": "uint256" },
+      { "name": "market", "type": "address", "indexed": true, "internalType": "address" },
+      { "name": "updateType", "type": "string", "indexed": false, "internalType": "string" },
+      {
+        "name": "config",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IRangeValidationModule.RangeConfig",
+        "components": [
+          { "name": "maxIncrease", "type": "uint120", "internalType": "uint120" },
+          { "name": "maxDecrease", "type": "uint120", "internalType": "uint120" },
+          { "name": "isIncreaseRelative", "type": "bool", "internalType": "bool" },
+          { "name": "isDecreaseRelative", "type": "bool", "internalType": "bool" }
+        ]
+      }
+    ]
   }
 ];


### PR DESCRIPTION
## Summary

- Adds `DefaultRangeConfigSet` and `MarketRangeConfigSet` event signatures from `IRangeValidationModule` to `eventDb.ts` so that `RANGE_VALIDATION_MODULE` contract events are decoded in diff reports instead of showing raw topics
- Fixes undecoded events visible in [aave-proposals-v3#996](https://github.com/aave-dao/aave-proposals-v3/pull/996/changes) for `MiscInkWhitelabel.RANGE_VALIDATION_MODULE`
- Also fixes a pre-existing bug in `formatValue` where `JSON.stringify` was called on decoded struct/tuple args containing `BigInt` values, causing a crash

## Checklist

- [ ] Added a [changeset](https://github.com/changesets/changesets) if this modifies a published package (`pnpm changeset`)