### PR TITLE
fix: check e-mode before PL_BORROW_CAP_BORROW_DISABLED

### DIFF
--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -7,6 +7,7 @@ import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import {SafeERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
 import {ReserveConfiguration} from 'aave-v3-origin/contracts/protocol/libraries/configuration/ReserveConfiguration.sol';
+import {EModeConfiguration} from 'aave-v3-origin/contracts/protocol/libraries/configuration/EModeConfiguration.sol';
 import {PercentageMath} from 'aave-v3-origin/contracts/protocol/libraries/math/PercentageMath.sol';
 import {WadRayMath} from 'aave-v3-origin/contracts/protocol/libraries/math/WadRayMath.sol';
 import {IDefaultInterestRateStrategyV2} from 'aave-v3-origin/contracts/interfaces/IDefaultInterestRateStrategyV2.sol';
@@ -127,13 +128,14 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
       );
     }
 
-    configChangePlausibilityTest(configBefore, configAfter);
+    configChangePlausibilityTest(pool, configBefore, configAfter);
 
     if (runE2E) e2eTest(pool);
     return (configBefore, configAfter);
   }
 
   function configChangePlausibilityTest(
+    IPool pool,
     ReserveConfig[] memory configBefore,
     ReserveConfig[] memory configAfter
   ) public view {
@@ -144,10 +146,16 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
       if (i < configsBeforeLength) {
         // borrow increase should only happen on assets with borrowing enabled
         // unless it is setting a borrow cap for the first time
+        // or the asset is borrowable in an e-mode (matching ValidationLogic.validateBorrow)
         if (
           configBefore[i].borrowCap < configAfter[i].borrowCap && configBefore[i].borrowCap != 0
         ) {
-          require(configAfter[i].borrowingEnabled, 'PL_BORROW_CAP_BORROW_DISABLED');
+          if (!configAfter[i].borrowingEnabled) {
+            require(
+              _isBorrowableInAnyEMode(pool, configAfter[i].underlying),
+              'PL_BORROW_CAP_BORROW_DISABLED'
+            );
+          }
         }
       } else {
         // at least newly listed assets should never have a supply cap exceeding total supply
@@ -167,6 +175,20 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
         require(configAfter[i].borrowCap <= configAfter[i].supplyCap, 'PL_SUPPLY_LT_BORROW');
       }
     }
+  }
+
+  function _isBorrowableInAnyEMode(IPool pool, address asset) internal view returns (bool) {
+    uint16 reserveId = pool.getReserveData(asset).id;
+    for (uint8 categoryId = 1; categoryId != 0; categoryId++) {
+      uint128 borrowableBitmap = pool.getEModeCategoryBorrowableBitmap(categoryId);
+      if (
+        borrowableBitmap != 0 &&
+        EModeConfiguration.isReserveEnabledOnBitmap(borrowableBitmap, reserveId)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -179,8 +179,8 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
 
   function _isBorrowableInAnyEMode(IPool pool, address asset) internal view returns (bool) {
     uint16 reserveId = pool.getReserveData(asset).id;
-    for (uint8 categoryId = 1; categoryId != 0; categoryId++) {
-      uint128 borrowableBitmap = pool.getEModeCategoryBorrowableBitmap(categoryId);
+    for (uint256 categoryId = 1; categoryId <= 255; categoryId++) {
+      uint128 borrowableBitmap = pool.getEModeCategoryBorrowableBitmap(uint8(categoryId));
       if (
         borrowableBitmap != 0 &&
         EModeConfiguration.isReserveEnabledOnBitmap(borrowableBitmap, reserveId)

--- a/tests/ProtocolV3TestBase.t.sol
+++ b/tests/ProtocolV3TestBase.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import 'forge-std/Test.sol';
 import {ProtocolV3TestBase, ReserveConfig} from '../src/ProtocolV3TestBase.sol';
+import {IPool, IPoolAddressesProvider, IPoolConfigurator} from 'aave-address-book/AaveV3.sol';
 import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
 import {AaveV3Polygon, AaveV3PolygonAssets} from 'aave-address-book/AaveV3Polygon.sol';
 import {AaveV3Optimism, AaveV3OptimismAssets} from 'aave-address-book/AaveV3Optimism.sol';
@@ -183,6 +184,100 @@ contract ProtocolV3TestMantleSnapshot is ProtocolV3TestBase {
 
   // overriding the executor storage check as payload artifacts does not exists
   function _validateNoExecutorStorageChange(address) internal view override {}
+}
+
+contract ProtocolV3TestPlausibilityEMode is ProtocolV3TestBase {
+  function setUp() public {
+    vm.createSelectFork('mainnet', 24655671);
+  }
+
+  function test_borrowCapIncrease_borrowDisabled_noEMode_reverts() public {
+    ReserveConfig[] memory configsBefore = _getReservesConfigs(AaveV3Ethereum.POOL);
+    ReserveConfig[] memory configsAfter = _getReservesConfigs(AaveV3Ethereum.POOL);
+
+    // pick first asset that has borrowing enabled and a borrow cap
+    uint256 idx;
+    for (uint256 i; i < configsAfter.length; i++) {
+      if (configsAfter[i].borrowingEnabled && configsAfter[i].borrowCap > 0) {
+        idx = i;
+        break;
+      }
+    }
+
+    // simulate: borrowing disabled, borrow cap increased
+    configsAfter[idx].borrowingEnabled = false;
+    configsAfter[idx].borrowCap = configsBefore[idx].borrowCap + 1;
+
+    // disable borrowing on-chain so _isBorrowableInAnyEMode reads real state
+    IPoolAddressesProvider provider = IPoolAddressesProvider(
+      AaveV3Ethereum.POOL.ADDRESSES_PROVIDER()
+    );
+    IPoolConfigurator configurator = IPoolConfigurator(provider.getPoolConfigurator());
+    vm.startPrank(provider.getACLAdmin());
+    configurator.setReserveBorrowing(configsAfter[idx].underlying, false);
+    // remove from all e-mode categories
+    uint16 reserveId = AaveV3Ethereum.POOL.getReserveData(configsAfter[idx].underlying).id;
+    for (uint256 cat = 1; cat <= 255; cat++) {
+      uint128 bitmap = AaveV3Ethereum.POOL.getEModeCategoryBorrowableBitmap(uint8(cat));
+      if (bitmap != 0 && (bitmap >> reserveId) & 1 != 0) {
+        configurator.setAssetBorrowableInEMode(configsAfter[idx].underlying, uint8(cat), false);
+      }
+    }
+    vm.stopPrank();
+
+    vm.expectRevert('PL_BORROW_CAP_BORROW_DISABLED');
+    this.configChangePlausibilityTest(AaveV3Ethereum.POOL, configsBefore, configsAfter);
+  }
+
+  function test_borrowCapIncrease_borrowDisabled_eModeBorrowable_passes() public {
+    ReserveConfig[] memory configsBefore = _getReservesConfigs(AaveV3Ethereum.POOL);
+    ReserveConfig[] memory configsAfter = _getReservesConfigs(AaveV3Ethereum.POOL);
+
+    uint256 idx;
+    for (uint256 i; i < configsAfter.length; i++) {
+      if (configsAfter[i].borrowingEnabled && configsAfter[i].borrowCap > 0) {
+        idx = i;
+        break;
+      }
+    }
+
+    // simulate: borrowing disabled, borrow cap increased
+    configsAfter[idx].borrowingEnabled = false;
+    configsAfter[idx].borrowCap = configsBefore[idx].borrowCap + 1;
+
+    IPoolAddressesProvider provider = IPoolAddressesProvider(
+      AaveV3Ethereum.POOL.ADDRESSES_PROVIDER()
+    );
+    IPoolConfigurator configurator = IPoolConfigurator(provider.getPoolConfigurator());
+    vm.startPrank(provider.getACLAdmin());
+    // disable standard borrowing
+    configurator.setReserveBorrowing(configsAfter[idx].underlying, false);
+    // ensure asset is borrowable in e-mode category 1
+    // first ensure category 1 exists
+    configurator.setEModeCategory(1, 90_00, 93_00, 101_00, 'test');
+    configurator.setAssetBorrowableInEMode(configsAfter[idx].underlying, 1, true);
+    vm.stopPrank();
+
+    // should pass because asset is borrowable in e-mode
+    this.configChangePlausibilityTest(AaveV3Ethereum.POOL, configsBefore, configsAfter);
+  }
+
+  function test_borrowCapIncrease_borrowEnabled_passes() public {
+    ReserveConfig[] memory configsBefore = _getReservesConfigs(AaveV3Ethereum.POOL);
+    ReserveConfig[] memory configsAfter = _getReservesConfigs(AaveV3Ethereum.POOL);
+
+    uint256 idx;
+    for (uint256 i; i < configsAfter.length; i++) {
+      if (configsAfter[i].borrowingEnabled && configsAfter[i].borrowCap > 0) {
+        idx = i;
+        break;
+      }
+    }
+
+    // borrow cap increased, borrowing still enabled — should pass
+    configsAfter[idx].borrowCap = configsBefore[idx].borrowCap + 1;
+    this.configChangePlausibilityTest(AaveV3Ethereum.POOL, configsBefore, configsAfter);
+  }
 }
 
 contract ProtocolV3TestStorageValidation is ProtocolV3TestBase {


### PR DESCRIPTION
## Summary
- Updated `configChangePlausibilityTest` signature to accept `IPool pool` as a new parameter (breaking change for direct callers)
- Updated `configChangePlausibilityTest` to check if an asset is borrowable in any e-mode category before reverting with `PL_BORROW_CAP_BORROW_DISABLED`, matching the [ValidationLogic.validateBorrow](https://github.com/aave-dao/aave-v3-origin/blob/1e3d70c4151a94166ebc59e2eaa4aff6e6ba6978/src/contracts/protocol/libraries/logic/ValidationLogic.sol#L143-L153) logic where e-mode borrowable assets don't require `borrowingEnabled`
- Added `_isBorrowableInAnyEMode` helper that iterates all 255 e-mode categories checking the `borrowableBitmap`
- Added three tests covering: borrow cap increase with borrowing disabled and no e-mode (reverts), with e-mode borrowable (passes), and with borrowing enabled (passes)


Notice that I took the choice to not update the zkSync code as all instances are deprecated.

## Test plan
- [x] `forge test --match-contract ProtocolV3TestPlausibilityEMode` — all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)