### PR TITLE
CCTP Bridge Steward

### DIFF
--- a/scripts/DeployCCTPBridge.s.sol
+++ b/scripts/DeployCCTPBridge.s.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3Arbitrum} from 'aave-address-book/AaveV3Arbitrum.sol';
+import {AaveV3Optimism} from 'aave-address-book/AaveV3Optimism.sol';
+import {AaveV3Polygon} from 'aave-address-book/AaveV3Polygon.sol';
+import {AaveV3Base} from 'aave-address-book/AaveV3Base.sol';
+import {ArbitrumScript, BaseScript, EthereumScript, OptimismScript, PolygonScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveCctpBridge} from 'src/bridges/cctp/AaveCctpBridge.sol';
+import {CctpConstants} from 'src/bridges/cctp/CctpConstants.sol';
+
+address constant TOKEN_LOGIC = 0x3765A685a401622C060E5D700D9ad89413363a91;
+address constant GUARDIAN = 0x3765A685a401622C060E5D700D9ad89413363a91;
+
+contract DeployCCTPBridgeEthereum is EthereumScript {
+  function run() external broadcast {
+    bytes32 salt = 'Aave CCTP Bridge';
+    new AaveCctpBridge{salt: salt}(
+      CctpConstants.ETHEREUM_TOKEN_MESSENGER,
+      CctpConstants.ETHEREUM_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+  }
+}
+
+contract DeployCCTPBridgeArbitrum is ArbitrumScript {
+  function run() external broadcast {
+    bytes32 salt = 'Aave CCTP Bridge';
+    new AaveCctpBridge{salt: salt}(
+      CctpConstants.ARBITRUM_TOKEN_MESSENGER,
+      CctpConstants.ARBITRUM_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Arbitrum.COLLECTOR)
+    );
+  }
+}
+
+contract DeployCCTPBridgeOptimism is OptimismScript {
+  function run() external broadcast {
+    bytes32 salt = 'Aave CCTP Bridge';
+    new AaveCctpBridge{salt: salt}(
+      CctpConstants.OPTIMISM_TOKEN_MESSENGER,
+      CctpConstants.OPTIMISM_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Optimism.COLLECTOR)
+    );
+  }
+}
+
+contract DeployCCTPBridgePolygon is PolygonScript {
+  function run() external broadcast {
+    bytes32 salt = 'Aave CCTP Bridge';
+    new AaveCctpBridge{salt: salt}(
+      CctpConstants.POLYGON_TOKEN_MESSENGER,
+      CctpConstants.POLYGON_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Polygon.COLLECTOR)
+    );
+  }
+}
+
+contract DeployCCTPBridgeBase is BaseScript {
+  function run() external broadcast {
+    bytes32 salt = 'Aave CCTP Bridge';
+    new AaveCctpBridge{salt: salt}(
+      CctpConstants.BASE_TOKEN_MESSENGER,
+      CctpConstants.BASE_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Base.COLLECTOR)
+    );
+  }
+}

--- a/src/bridges/cctp/AaveCctpBridge.sol
+++ b/src/bridges/cctp/AaveCctpBridge.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ICollector} from 'aave-address-book/AaveV3.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {OwnableWithGuardian} from 'solidity-utils/contracts/access-control/OwnableWithGuardian.sol';
+import {RescuableBase} from 'solidity-utils/contracts/utils/RescuableBase.sol';
+
+import {IAaveCctpBridge} from './interfaces/IAaveCctpBridge.sol';
+import {IMessageTransmitterV2} from './interfaces/IMessageTransmitterV2.sol';
+import {ITokenMessengerV2} from './interfaces/ITokenMessengerV2.sol';
+
+/// @title AaveCctpBridge
+/// @author stevyhacker (TokenLogic)
+/// @notice Helper contract to bridge USDC using Circle's CCTP V2
+contract AaveCctpBridge is OwnableWithGuardian, RescuableBase, IAaveCctpBridge {
+  using SafeERC20 for IERC20;
+
+  /// @notice Finality threshold constant for Fast Transfer is 1000 and means just tx confirmation is sufficient
+  /// @dev Required confirmations per chain https://developers.circle.com/cctp/required-block-confirmations#cctp-fast-message-attestation-times
+  uint32 public constant FAST = 1000;
+
+  /// @notice Finality threshold constant for Standard Transfer is 2000 and means hard finality is requested
+  /// @dev Required confirmations per chain https://developers.circle.com/cctp/required-block-confirmations#cctp-standard-message-attestation-times
+  uint32 public constant STANDARD = 2000;
+
+  /// @inheritdoc IAaveCctpBridge
+  address public immutable TOKEN_MESSENGER;
+
+  /// @inheritdoc IAaveCctpBridge
+  address public immutable USDC;
+
+  /// @inheritdoc IAaveCctpBridge
+  address public immutable COLLECTOR;
+
+  /// @inheritdoc IAaveCctpBridge
+  uint32 public immutable LOCAL_DOMAIN;
+
+  /// @inheritdoc IAaveCctpBridge
+  mapping(bytes32 receiver => bool allowed) public isAllowedReceiver;
+
+  /// @param tokenMessenger The TokenMessengerV2 address on this chain
+  /// @param usdc The USDC token address on this chain
+  /// @param owner The owner of the contract upon deployment
+  /// @param guardian The initial guardian of the contract upon deployment
+  /// @param collector The address of the source collector on this chain
+  constructor(
+    address tokenMessenger,
+    address usdc,
+    address owner,
+    address guardian,
+    address collector
+  ) OwnableWithGuardian(owner, guardian) {
+    if (tokenMessenger == address(0)) revert InvalidZeroAddress();
+    if (usdc == address(0)) revert InvalidZeroAddress();
+    if (guardian == address(0)) revert InvalidZeroAddress();
+    if (collector == address(0)) revert InvalidZeroAddress();
+
+    TOKEN_MESSENGER = tokenMessenger;
+    USDC = usdc;
+    COLLECTOR = collector;
+
+    address localMessageTransmitter = ITokenMessengerV2(tokenMessenger).localMessageTransmitter();
+    LOCAL_DOMAIN = IMessageTransmitterV2(localMessageTransmitter).localDomain();
+  }
+
+  /// @dev Enables receiving native tokens so they can be rescued back to COLLECTOR if needed
+  receive() external payable {}
+
+  /// @inheritdoc IAaveCctpBridge
+  function bridge(
+    uint32 destinationDomain,
+    uint256 amount,
+    address receiver,
+    uint256 maxFee,
+    TransferSpeed speed
+  ) external onlyOwnerOrGuardian {
+    _bridge(destinationDomain, amount, bytes32(uint256(uint160(receiver))), maxFee, speed);
+  }
+
+  /// @inheritdoc IAaveCctpBridge
+  function bridgeNonEvm(
+    uint32 destinationDomain,
+    uint256 amount,
+    bytes32 receiver,
+    uint256 maxFee,
+    TransferSpeed speed
+  ) external onlyOwnerOrGuardian {
+    _bridge(destinationDomain, amount, receiver, maxFee, speed);
+  }
+
+  /// @inheritdoc IAaveCctpBridge
+  function setAllowedReceiver(address receiver, bool allowed) external onlyOwner {
+    if (receiver == address(0)) revert InvalidZeroAddress();
+    isAllowedReceiver[bytes32(uint256(uint160(receiver)))] = allowed;
+  }
+
+  /// @inheritdoc IAaveCctpBridge
+  function setAllowedReceiverNonEVM(bytes32 receiver, bool allowed) external onlyOwner {
+    if (receiver == bytes32(0)) revert InvalidZeroAddress();
+    isAllowedReceiver[receiver] = allowed;
+  }
+
+  /// @inheritdoc IAaveCctpBridge
+  function rescueToken(address token) external onlyOwnerOrGuardian {
+    _emergencyTokenTransfer(token, COLLECTOR, type(uint256).max);
+  }
+
+  /// @inheritdoc IAaveCctpBridge
+  function rescueEth() external onlyOwnerOrGuardian {
+    _emergencyEtherTransfer(COLLECTOR, address(this).balance);
+  }
+
+  /// @inheritdoc RescuableBase
+  function maxRescue(address token) public view override(RescuableBase) returns (uint256) {
+    return IERC20(token).balanceOf(address(this));
+  }
+
+  /// @notice Executes a USDC bridge transfer using CCTP V2
+  /// @dev Pulls USDC from the source collector, approves the token messenger, and burns for minting on the destination domain
+  /// @param destinationDomain The CCTP domain of the destination chain
+  /// @param amount The amount of USDC to bridge, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param receiver The destination receiver identifier
+  /// @param maxFee Maximum fee willing to pay for a Fast Transfer, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param speed Transfer speed (Fast or Standard)
+  function _bridge(
+    uint32 destinationDomain,
+    uint256 amount,
+    bytes32 receiver,
+    uint256 maxFee,
+    TransferSpeed speed
+  ) internal {
+    if (amount == 0) revert InvalidZeroAmount();
+    if (destinationDomain == LOCAL_DOMAIN) revert InvalidDestinationDomain();
+    if (!isAllowedReceiver[receiver]) revert OnlyAllowedRecipients();
+
+    uint32 finalityThreshold = speed == TransferSpeed.Fast ? FAST : STANDARD;
+
+    ICollector(COLLECTOR).transfer(IERC20(USDC), address(this), amount);
+    IERC20(USDC).forceApprove(TOKEN_MESSENGER, amount);
+
+    ITokenMessengerV2(TOKEN_MESSENGER).depositForBurn(
+      amount,
+      destinationDomain,
+      receiver,
+      USDC,
+      bytes32(0),
+      maxFee,
+      finalityThreshold
+    );
+
+    emit Bridge(USDC, destinationDomain, receiver, amount, speed);
+  }
+}

--- a/src/bridges/cctp/CctpConstants.sol
+++ b/src/bridges/cctp/CctpConstants.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title CctpConstants
+/// @notice Constants for CCTP V2 bridge testing
+/// @dev Domain IDs from https://developers.circle.com/cctp/cctp-supported-blockchains
+library CctpConstants {
+  // CCTP Domain IDs
+  uint32 public constant ETHEREUM_DOMAIN = 0;
+  uint32 public constant AVALANCHE_DOMAIN = 1;
+  uint32 public constant OPTIMISM_DOMAIN = 2;
+  uint32 public constant ARBITRUM_DOMAIN = 3;
+  uint32 public constant SOLANA_DOMAIN = 5;
+  uint32 public constant BASE_DOMAIN = 6;
+  uint32 public constant POLYGON_DOMAIN = 7;
+  uint32 public constant UNICHAIN_DOMAIN = 10;
+  uint32 public constant LINEA_DOMAIN = 11;
+  uint32 public constant SONIC_DOMAIN = 13;
+  uint32 public constant MONAD_DOMAIN = 15;
+  uint32 public constant INK_DOMAIN = 21;
+
+  // Finality Thresholds
+  uint32 public constant FAST_FINALITY_THRESHOLD = 1000;
+  uint32 public constant STANDARD_FINALITY_THRESHOLD = 2000;
+
+  // Mainnet TokenMessengerV2 addresses
+  // https://etherscan.io/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant ETHEREUM_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://arbiscan.io/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant ARBITRUM_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://basescan.org/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant BASE_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://optimistic.etherscan.io/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant OPTIMISM_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://polygonscan.com/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant POLYGON_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+
+  // Mainnet USDC addresses
+  // https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+  address public constant ETHEREUM_USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  // https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831
+  address public constant ARBITRUM_USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
+  // https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+  address public constant BASE_USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+  // https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85
+  address public constant OPTIMISM_USDC = 0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85;
+  // https://polygonscan.com/address/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
+  address public constant POLYGON_USDC = 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359;
+}

--- a/src/bridges/cctp/README.md
+++ b/src/bridges/cctp/README.md
@@ -1,0 +1,149 @@
+# Aave CCTP Bridge
+
+The AaveCctpBridge is a contract to facilitate bridging USDC across chains using Circle's Cross-Chain Transfer Protocol (CCTP) V2. The contract provides a simplified interface for Aave DAO governance to move USDC between supported networks.
+
+## Features
+
+- Bridge USDC to any CCTP V2 supported destination chain
+- Support for both Fast and Standard transfer speeds
+- Steward access model (`owner` + `guardian`) for operational execution
+- Bridges pull USDC from a pre-configured source `COLLECTOR`
+- Destination receivers (EVM and non-EVM) must be explicitly allowlisted by owner
+
+## Transfer Speeds
+
+CCTP V2 supports two transfer speed modes:
+
+| Speed    | Finality Threshold | Description                      |
+| -------- | ------------------ | -------------------------------- |
+| Fast     | 1000               | Faster transfer, may incur a fee |
+| Standard | 2000               | Slower transfer, no fee          |
+
+Essentially, the Fast mode is just a tx confirmation is sufficient while the Standard mode requires hard finality and a large number of mined blocks.
+The exact numbers per chain can be found in the Circle documentation:
+
+- [cctp-fast-message-attestation-times](https://developers.circle.com/cctp/required-block-confirmations#cctp-fast-message-attestation-times)
+- [cctp-standard-message-attestation-times](https://developers.circle.com/cctp/required-block-confirmations#cctp-standard-message-attestation-times)
+
+The `maxFee` parameter allows specifying the maximum fee (in USDC) willing to pay for Fast transfers.
+
+- For `TransferSpeed.Fast`, `maxFee` is the maximum fee you are willing to pay (in USDC base units).
+- For `TransferSpeed.Standard`, fees are `0` (per Iris) so `maxFee` should be set to `0`.
+
+### Querying fees for Fast transfers
+
+Circle exposes the minimum fee rate for a route (in basis points) via Iris. To derive a `maxFee` for `TransferSpeed.Fast`, query:
+
+Example:
+
+```bash
+# Arbitrum (3) -> Base (6)
+curl -s "https://iris-api.circle.com/v2/burn/USDC/fees/3/6"
+```
+
+- Mainnet: `GET https://iris-api.circle.com/v2/burn/USDC/fees/{sourceDomainId}/{destDomainId}`
+- Testnet: `GET https://iris-api-sandbox.circle.com/v2/burn/USDC/fees/{sourceDomainId}/{destDomainId}`
+
+The response includes entries for `finalityThreshold` `1000` (Fast / Confirmed) and `2000` (Standard / Finalized).
+
+To derive a `maxFee` for `TransferSpeed.Fast`, use the `minimumFee` where `finalityThreshold == 1000`, then compute (rounding up):
+
+`maxFee = ceil(amount * minimumFee / 10_000)`
+
+**Denomination / decimals**
+
+- Onchain, both `amount` and `maxFee` are expected in the token’s smallest unit (for USDC: `6` decimals, i.e. `1 USDC = 1_000_000` base units).
+- The Iris API returns a fee _rate_ (`minimumFee` in bps). This value can be fractional (e.g. `1.3` bps), so do the computation off-chain using decimal math and then round up to base units.
+
+Example (1000 USDC, `minimumFee = 1.3` bps):
+
+- `amountBaseUnits = 1000 * 1_000_000 = 1_000_000_000`
+- choose `scale = 10` (one decimal place), so `minimumFeeScaled = 13`
+- `maxFeeBaseUnits = ceil(1_000_000_000 * 13 / (10_000 * 10)) = 130_000`
+- `130_000` base units = `0.13` USDC
+
+Note: the API returns a fee _rate_ (`minimumFee` in bps), not a precomputed absolute `maxFee`; you derive the absolute value from your `amount`.
+
+## Permissions
+
+The contract implements `OwnableWithGuardian` for permissioned functions.
+The owner is expected to be the respective network's Level 1 Executor (Governance), while the guardian provides an operational backup path.
+
+`bridge()` and `bridgeNonEvm()` can be called by `owner` or `guardian`.
+Allowed receivers can only be configured by `owner`.
+
+## Security Considerations
+
+The contract exposes `rescueToken()` and `rescueEth()`, callable by `owner` or `guardian`.
+Both rescue methods always transfer assets back to `COLLECTOR` (not arbitrary recipients).
+
+## CCTP Domain IDs
+
+Domain IDs are defined by Circle's CCTP. The complete list can be found in the [CCTP documentation](https://developers.circle.com/cctp/cctp-supported-blockchains).
+
+| Network   | Domain ID |
+| --------- | --------- |
+| Ethereum  | 0         |
+| Avalanche | 1         |
+| Optimism  | 2         |
+| Arbitrum  | 3         |
+| Solana    | 5         |
+| Base      | 6         |
+| Polygon   | 7         |
+| Unichain  | 10        |
+| Linea     | 11        |
+| Sonic     | 13        |
+| Monad     | 15        |
+| Ink       | 21        |
+
+## Functions
+
+```solidity
+function bridge(
+  uint32 destinationDomain,
+  uint256 amount,
+  address receiver,
+  uint256 maxFee,
+  TransferSpeed speed
+) external onlyOwnerOrGuardian;
+
+function bridgeNonEvm(
+  uint32 destinationDomain,
+  uint256 amount,
+  bytes32 receiver,
+  uint256 maxFee,
+  TransferSpeed speed
+) external onlyOwnerOrGuardian;
+```
+
+Bridges USDC to a destination chain. The bridge contract pulls USDC from the source-chain `COLLECTOR` via `ICollector.transfer`, so the bridge must hold the Collector `FUNDS_ADMIN` role. The caller provides a destination receiver per transfer.
+Receivers must be allowlisted (`setAllowedReceiver` for EVM and `setAllowedReceiverNonEVM` for non-EVM).
+
+Parameters:
+
+- `destinationDomain`: The CCTP domain ID of the destination chain
+- `amount`: Amount of USDC to bridge (must be > 0)
+- `receiver`: Destination recipient (EVM address for `bridge`, bytes32 identifier for `bridgeNonEvm`)
+- `maxFee`: Maximum fee in USDC for Fast transfers
+- `speed`: `TransferSpeed.Fast` or `TransferSpeed.Standard`
+
+## Contract Addresses
+
+### TokenMessengerV2 (CCTP V2)
+
+All networks use the same TokenMessengerV2 address: `0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d`
+
+### Native USDC Addresses
+
+| Network  | USDC Address                                 |
+| -------- | -------------------------------------------- |
+| Ethereum | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| Arbitrum | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
+| Base     | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Optimism | `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85` |
+| Polygon  | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
+
+## References
+
+- [CCTP V2 Documentation](https://developers.circle.com/cctp)
+- [CCTP Supported Blockchains](https://developers.circle.com/cctp/cctp-supported-blockchains)

--- a/src/bridges/cctp/interfaces/IAaveCctpBridge.sol
+++ b/src/bridges/cctp/interfaces/IAaveCctpBridge.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IAaveCctpBridge
+/// @author TokenLogic
+/// @notice Interface for the Aave CCTP V2 Bridge adapter for USDC cross-chain transfers
+interface IAaveCctpBridge {
+  /// @notice Transfer speed options for CCTP V2
+  enum TransferSpeed {
+    Fast, // Finality threshold 1000 - faster but with fee
+    Standard // Finality threshold 2000 - slower but potentially lower/no fee
+  }
+
+  /// @notice Emitted when a bridge transfer is initiated
+  /// @param token The address of the bridged token (USDC)
+  /// @param destinationDomain The CCTP domain of the destination chain
+  /// @param receiver The recipient address on the destination chain (bytes32 to support non-EVM)
+  /// @param amount The amount of tokens bridged
+  /// @param speed The transfer speed used (Fast or Standard)
+  event Bridge(
+    address indexed token,
+    uint32 indexed destinationDomain,
+    bytes32 indexed receiver,
+    uint256 amount,
+    TransferSpeed speed
+  );
+
+  /// @dev Amount provided is zero
+  error InvalidZeroAmount();
+
+  /// @dev Destination domain matches local domain
+  error InvalidDestinationDomain();
+
+  /// @dev Constructor parameter is zero address
+  error InvalidZeroAddress();
+
+  /// @dev Receiver is not allowlisted
+  error OnlyAllowedRecipients();
+
+  /// @notice Bridges USDC to a destination chain using CCTP V2
+  /// @param destinationDomain The CCTP domain of the destination chain
+  /// @param amount The amount of USDC to bridge, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param receiver The EVM receiver address on destination chain
+  /// @param maxFee Maximum fee willing to pay for a Fast Transfer, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param speed Transfer speed (Fast or Standard)
+  function bridge(
+    uint32 destinationDomain,
+    uint256 amount,
+    address receiver,
+    uint256 maxFee,
+    TransferSpeed speed
+  ) external;
+
+  /// @notice Bridges USDC to a destination chain using CCTP V2 with a non-EVM receiver identifier
+  /// @param destinationDomain The CCTP domain of the destination chain
+  /// @param amount The amount of USDC to bridge, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param receiver The non-EVM receiver identifier
+  /// @param maxFee Maximum fee willing to pay for a Fast Transfer, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param speed Transfer speed (Fast or Standard)
+  function bridgeNonEvm(
+    uint32 destinationDomain,
+    uint256 amount,
+    bytes32 receiver,
+    uint256 maxFee,
+    TransferSpeed speed
+  ) external;
+
+  /// @notice Sets whether a receiver is allowed for bridge execution
+  /// @param receiver The destination receiver address
+  /// @param allowed Whether the receiver is allowed
+  function setAllowedReceiver(address receiver, bool allowed) external;
+
+  /// @notice Sets whether a non-EVM receiver is allowed for bridge execution
+  /// @param receiver The destination receiver identifier
+  /// @param allowed Whether the receiver is allowed
+  function setAllowedReceiverNonEVM(bytes32 receiver, bool allowed) external;
+
+  /// @notice Rescues an ERC20 token balance to the source collector
+  /// @param token The token address to rescue
+  function rescueToken(address token) external;
+
+  /// @notice Rescues native token balance to the source collector
+  function rescueEth() external;
+
+  /// @notice Returns the TokenMessengerV2 contract address
+  /// @return Address of the CCTP V2 TokenMessenger
+  function TOKEN_MESSENGER() external view returns (address);
+
+  /// @notice Returns the USDC token address on this chain
+  /// @return Address of the USDC token
+  function USDC() external view returns (address);
+
+  /// @notice Returns the source collector address on this chain
+  /// @return Address of the source collector
+  function COLLECTOR() external view returns (address);
+
+  /// @notice Returns the local CCTP domain identifier
+  /// @return The domain ID for this chain
+  function LOCAL_DOMAIN() external view returns (uint32);
+
+  /// @notice Returns whether a receiver is allowed for bridge execution
+  /// @param receiver The destination receiver identifier
+  /// @return Whether the receiver is allowed
+  function isAllowedReceiver(bytes32 receiver) external view returns (bool);
+}

--- a/src/bridges/cctp/interfaces/IMessageTransmitterV2.sol
+++ b/src/bridges/cctp/interfaces/IMessageTransmitterV2.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IMessageTransmitterV2
+/// @notice Minimal interface for Circle's CCTP V2 MessageTransmitter contract
+interface IMessageTransmitterV2 {
+  function localDomain() external view returns (uint32);
+}

--- a/src/bridges/cctp/interfaces/ITokenMessengerV2.sol
+++ b/src/bridges/cctp/interfaces/ITokenMessengerV2.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title ITokenMessengerV2
+/// @notice Interface for Circle's CCTP V2 TokenMessenger contract
+/// @dev https://developers.circle.com/cctp/evm-smart-contracts#tokenmessengerv2
+interface ITokenMessengerV2 {
+  /// @notice Address of the local MessageTransmitterV2 contract
+  function localMessageTransmitter() external view returns (address);
+
+  /// @notice Deposits and burns tokens from sender to be minted on destination domain
+  /// @param amount Amount of tokens to deposit and burn
+  /// @param destinationDomain Destination domain identifier
+  /// @param mintRecipient Address of mint recipient on destination domain (as bytes32)
+  /// @param burnToken Address of contract to burn deposited tokens
+  /// @param destinationCaller Address that can call receiveMessage on destination (bytes32(0) for any)
+  /// @param maxFee Maximum fee for Fast Transfer (in burn token units)
+  /// @param minFinalityThreshold Minimum finality level (1000 for Fast, 2000 for Standard)
+  function depositForBurn(
+    uint256 amount,
+    uint32 destinationDomain,
+    bytes32 mintRecipient,
+    address burnToken,
+    bytes32 destinationCaller,
+    uint256 maxFee,
+    uint32 minFinalityThreshold
+  ) external;
+}

--- a/tests/bridges/cctp/AaveCctpBridgeFork.t.sol
+++ b/tests/bridges/cctp/AaveCctpBridgeFork.t.sol
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IAccessControl} from 'openzeppelin-contracts/contracts/access/IAccessControl.sol';
+import {Test} from 'forge-std/Test.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+import {IWithGuardian} from 'solidity-utils/contracts/access-control/interfaces/IWithGuardian.sol';
+
+import {AaveCctpBridge} from 'src/bridges/cctp/AaveCctpBridge.sol';
+import {IAaveCctpBridge} from 'src/bridges/cctp/interfaces/IAaveCctpBridge.sol';
+import {CctpConstants} from 'src/bridges/cctp/CctpConstants.sol';
+
+contract AaveCctpBridgeForkTestBase is Test {
+  AaveCctpBridge public bridge;
+  IERC20 public usdc;
+  address public owner = makeAddr('owner');
+  address public guardian = makeAddr('guardian');
+  address public collector = address(AaveV3Ethereum.COLLECTOR);
+  address public alice = makeAddr('alice');
+  address public receiver = makeAddr('receiver');
+
+  uint256 public constant AMOUNT = 10_000e6; // 10k USDC
+
+  function _deployBridge(address bridgeCollector) internal returns (AaveCctpBridge) {
+    return
+      new AaveCctpBridge(
+        CctpConstants.ETHEREUM_TOKEN_MESSENGER,
+        CctpConstants.ETHEREUM_USDC,
+        owner,
+        guardian,
+        bridgeCollector
+      );
+  }
+
+  function _addressToBytes32(address addr) internal pure returns (bytes32) {
+    return bytes32(uint256(uint160(addr)));
+  }
+
+  function _fundCollector(uint256 amount) internal {
+    deal(address(usdc), collector, amount);
+  }
+
+  function setUp() public virtual {
+    string memory rpcUrl = vm.envOr('RPC_MAINNET', string(''));
+    vm.createSelectFork(rpcUrl);
+
+    usdc = IERC20(CctpConstants.ETHEREUM_USDC);
+
+    bridge = _deployBridge(collector);
+
+    bytes32 fundsAdminRole = AaveV3Ethereum.COLLECTOR.FUNDS_ADMIN_ROLE();
+    vm.prank(AaveV3Ethereum.ACL_ADMIN);
+    IAccessControl(collector).grantRole(fundsAdminRole, address(bridge));
+
+    vm.startPrank(owner);
+    bridge.setAllowedReceiver(receiver, true);
+    bridge.setAllowedReceiverNonEVM(_addressToBytes32(receiver), true);
+    vm.stopPrank();
+  }
+
+  function _bridgeToEvm(
+    uint32 destinationDomain,
+    address destinationReceiver,
+    uint256 maxFee,
+    IAaveCctpBridge.TransferSpeed speed
+  ) internal {
+    _fundCollector(AMOUNT);
+    uint256 collectorBalanceBefore = usdc.balanceOf(collector);
+
+    vm.expectEmit(true, true, true, true, address(bridge));
+    emit IAaveCctpBridge.Bridge(
+      address(usdc),
+      destinationDomain,
+      _addressToBytes32(destinationReceiver),
+      AMOUNT,
+      speed
+    );
+
+    vm.startPrank(owner);
+    bridge.bridge(destinationDomain, AMOUNT, destinationReceiver, maxFee, speed);
+    vm.stopPrank();
+
+    assertEq(usdc.balanceOf(address(bridge)), 0, 'Bridge should have no USDC left');
+    assertEq(
+      usdc.balanceOf(collector),
+      collectorBalanceBefore - AMOUNT,
+      'Collector should transfer USDC'
+    );
+  }
+
+  function _bridgeToNonEvm(
+    uint32 destinationDomain,
+    bytes32 destinationReceiver,
+    uint256 maxFee,
+    IAaveCctpBridge.TransferSpeed speed
+  ) internal {
+    _fundCollector(AMOUNT);
+    uint256 collectorBalanceBefore = usdc.balanceOf(collector);
+
+    vm.expectEmit(true, true, true, true, address(bridge));
+    emit IAaveCctpBridge.Bridge(
+      address(usdc),
+      destinationDomain,
+      destinationReceiver,
+      AMOUNT,
+      speed
+    );
+
+    vm.startPrank(owner);
+    bridge.bridgeNonEvm(destinationDomain, AMOUNT, destinationReceiver, maxFee, speed);
+    vm.stopPrank();
+
+    assertEq(usdc.balanceOf(address(bridge)), 0, 'Bridge should have no USDC left');
+    assertEq(
+      usdc.balanceOf(collector),
+      collectorBalanceBefore - AMOUNT,
+      'Collector should transfer USDC'
+    );
+  }
+}
+
+contract BridgeEvmTest is AaveCctpBridgeForkTestBase {
+  function test_bridge_fast() public {
+    _bridgeToEvm(
+      CctpConstants.ARBITRUM_DOMAIN,
+      receiver,
+      AMOUNT / 100,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+  }
+
+  function test_bridge_fast_guardian() public {
+    _fundCollector(AMOUNT);
+    uint256 collectorBalanceBefore = usdc.balanceOf(collector);
+
+    vm.expectEmit(true, true, true, true, address(bridge));
+    emit IAaveCctpBridge.Bridge(
+      address(usdc),
+      CctpConstants.ARBITRUM_DOMAIN,
+      _addressToBytes32(receiver),
+      AMOUNT,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+
+    vm.prank(guardian);
+    bridge.bridge(
+      CctpConstants.ARBITRUM_DOMAIN,
+      AMOUNT,
+      receiver,
+      AMOUNT / 100,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+
+    assertEq(usdc.balanceOf(address(bridge)), 0, 'Bridge should have no USDC left');
+    assertEq(
+      usdc.balanceOf(collector),
+      collectorBalanceBefore - AMOUNT,
+      'Collector should transfer USDC'
+    );
+  }
+
+  function test_bridge_standard() public {
+    _bridgeToEvm(
+      CctpConstants.ARBITRUM_DOMAIN,
+      receiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Standard
+    );
+  }
+
+  function test_bridge_to_avalanche() public {
+    _bridgeToEvm(
+      CctpConstants.AVALANCHE_DOMAIN,
+      receiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Standard
+    );
+  }
+
+  function test_bridge_to_optimism() public {
+    _bridgeToEvm(
+      CctpConstants.OPTIMISM_DOMAIN,
+      receiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Standard
+    );
+  }
+
+  function test_bridge_to_polygon() public {
+    _bridgeToEvm(CctpConstants.POLYGON_DOMAIN, receiver, 0, IAaveCctpBridge.TransferSpeed.Standard);
+  }
+
+  function test_bridge_to_unichain() public {
+    _bridgeToEvm(
+      CctpConstants.UNICHAIN_DOMAIN,
+      receiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Standard
+    );
+  }
+
+  function test_bridge_to_linea() public {
+    _bridgeToEvm(CctpConstants.LINEA_DOMAIN, receiver, 0, IAaveCctpBridge.TransferSpeed.Standard);
+  }
+
+  function test_bridge_to_base() public {
+    _bridgeToEvm(CctpConstants.BASE_DOMAIN, receiver, 0, IAaveCctpBridge.TransferSpeed.Standard);
+  }
+
+  function test_revertsIf_callerNotOwnerOrGuardian() public {
+    vm.startPrank(alice);
+    vm.expectRevert(
+      abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, alice)
+    );
+    bridge.bridge(
+      CctpConstants.ARBITRUM_DOMAIN,
+      AMOUNT,
+      receiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+    vm.stopPrank();
+  }
+
+  function test_revertsIf_zeroAmount() public {
+    vm.startPrank(owner);
+    vm.expectRevert(IAaveCctpBridge.InvalidZeroAmount.selector);
+    bridge.bridge(
+      CctpConstants.ARBITRUM_DOMAIN,
+      0,
+      receiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+    vm.stopPrank();
+  }
+
+  function test_revertsIf_receiverNotAllowed() public {
+    address unallowedReceiver = makeAddr('unallowedReceiver');
+
+    vm.startPrank(owner);
+    vm.expectRevert(IAaveCctpBridge.OnlyAllowedRecipients.selector);
+    bridge.bridge(
+      CctpConstants.ARBITRUM_DOMAIN,
+      AMOUNT,
+      unallowedReceiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+    vm.stopPrank();
+  }
+
+  function test_revertsIf_zeroReceiver() public {
+    vm.startPrank(owner);
+    vm.expectRevert(IAaveCctpBridge.OnlyAllowedRecipients.selector);
+    bridge.bridge(
+      CctpConstants.ARBITRUM_DOMAIN,
+      AMOUNT,
+      address(0),
+      0,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+    vm.stopPrank();
+  }
+
+  function test_revertsIf_sameDestinationDomain() public {
+    vm.startPrank(owner);
+    vm.expectRevert(IAaveCctpBridge.InvalidDestinationDomain.selector);
+    bridge.bridge(
+      CctpConstants.ETHEREUM_DOMAIN,
+      AMOUNT,
+      receiver,
+      0,
+      IAaveCctpBridge.TransferSpeed.Fast
+    );
+    vm.stopPrank();
+  }
+}
+
+contract BridgeNonEvmTest is AaveCctpBridgeForkTestBase {
+  function test_bridge_to_solana() public {
+    _bridgeToNonEvm(
+      CctpConstants.SOLANA_DOMAIN,
+      _addressToBytes32(receiver),
+      0,
+      IAaveCctpBridge.TransferSpeed.Standard
+    );
+  }
+}
+
+contract ConstructorTest is AaveCctpBridgeForkTestBase {
+  function test_revertsIf_constructorTokenMessengerZero() public {
+    vm.expectRevert(IAaveCctpBridge.InvalidZeroAddress.selector);
+    new AaveCctpBridge(address(0), CctpConstants.ETHEREUM_USDC, owner, guardian, collector);
+  }
+
+  function test_revertsIf_constructorUsdcZero() public {
+    vm.expectRevert(IAaveCctpBridge.InvalidZeroAddress.selector);
+    new AaveCctpBridge(
+      CctpConstants.ETHEREUM_TOKEN_MESSENGER,
+      address(0),
+      owner,
+      guardian,
+      collector
+    );
+  }
+
+  function test_revertsIf_constructorGuardianZero() public {
+    vm.expectRevert(IAaveCctpBridge.InvalidZeroAddress.selector);
+    new AaveCctpBridge(
+      CctpConstants.ETHEREUM_TOKEN_MESSENGER,
+      CctpConstants.ETHEREUM_USDC,
+      owner,
+      address(0),
+      collector
+    );
+  }
+
+  function test_revertsIf_constructorCollectorZero() public {
+    vm.expectRevert(IAaveCctpBridge.InvalidZeroAddress.selector);
+    new AaveCctpBridge(
+      CctpConstants.ETHEREUM_TOKEN_MESSENGER,
+      CctpConstants.ETHEREUM_USDC,
+      owner,
+      guardian,
+      address(0)
+    );
+  }
+}
+
+contract SetAllowedReceiverTest is AaveCctpBridgeForkTestBase {
+  function test_revertsIf_setAllowedReceiverZeroAddress() public {
+    vm.prank(owner);
+    vm.expectRevert(IAaveCctpBridge.InvalidZeroAddress.selector);
+    bridge.setAllowedReceiver(address(0), true);
+  }
+}
+
+contract SetAllowedReceiverNonEvmTest is AaveCctpBridgeForkTestBase {
+  function test_revertsIf_setAllowedReceiverNonEvmZeroAddress() public {
+    vm.prank(owner);
+    vm.expectRevert(IAaveCctpBridge.InvalidZeroAddress.selector);
+    bridge.setAllowedReceiverNonEVM(bytes32(0), true);
+  }
+}
+
+contract RescuableTest is AaveCctpBridgeForkTestBase {
+  function test_rescueToken_guardian() public {
+    AaveCctpBridge rescueBridge = _deployBridge(receiver);
+    deal(address(usdc), address(rescueBridge), AMOUNT);
+
+    vm.prank(guardian);
+    rescueBridge.rescueToken(address(usdc));
+
+    assertEq(usdc.balanceOf(address(rescueBridge)), 0, 'Rescue bridge should have no USDC left');
+    assertEq(usdc.balanceOf(receiver), AMOUNT, 'Collector should receive rescued USDC');
+  }
+
+  function test_rescueEth_owner() public {
+    AaveCctpBridge rescueBridge = _deployBridge(receiver);
+    vm.deal(address(this), 1 ether);
+    uint256 bridgeBalanceBefore = address(rescueBridge).balance;
+    uint256 receiverBalanceBefore = receiver.balance;
+
+    (bool success, ) = address(rescueBridge).call{value: 1 ether}('');
+    assertTrue(success, 'Bridge should accept ETH');
+    assertEq(
+      address(rescueBridge).balance,
+      bridgeBalanceBefore + 1 ether,
+      'Bridge should hold the transferred ETH before rescue'
+    );
+
+    vm.prank(owner);
+    rescueBridge.rescueEth();
+
+    assertEq(address(rescueBridge).balance, 0, 'Bridge should have no ETH left');
+    assertEq(
+      receiver.balance,
+      receiverBalanceBefore + bridgeBalanceBefore + 1 ether,
+      'Collector should receive rescued ETH'
+    );
+  }
+
+  function test_maxRescue_returnsFullBalance() public {
+    AaveCctpBridge rescueBridge = _deployBridge(receiver);
+    deal(address(usdc), address(rescueBridge), AMOUNT);
+
+    assertEq(rescueBridge.maxRescue(address(usdc)), AMOUNT);
+  }
+}


### PR DESCRIPTION
## Description

Add a CCTP v2 Bridge adapter steward helper.
Allows for USDC transfers between CCTP supported chains. 


**Details**
[src/bridges/cctp/README.md](https://github.com/TokenLogic-com-au/aave-helpers/blob/2714be8aed44663877cb2629023b3bcd1b1d668d/src/bridges/cctp/)

[CCTP docs](https://developers.circle.com/cctp)
