### PR TITLE
fix: measure payload gas against real per-chain tx limit under isolation

### DIFF
--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -50,8 +50,18 @@ contract CommonTestBase is Test {
     return 16_777_216;
   }
 
-  function _assertPayloadGasWithinLimit(uint256 gasUsed) internal view {
+  function _assertPayloadGasWithinLimit(uint256 gasUsed) internal {
+    _requireIsolation();
     assertLt(gasUsed, (_getMaxPayloadGas() * 95) / 100, 'TX_GAS_LIMIT_EXCEEDED'); // 5% is kept as a buffer
+  }
+
+  // The gas check is only meaningful under isolation (cold storage + tx intrinsic), and there is no
+  // cheatcode to query or enable it. Detect it instead: under isolation a top-level call is metered as
+  // a transaction (>= 21000 intrinsic gas), otherwise ~0. Fail loudly rather than silently under-count.
+  function _requireIsolation() internal {
+    (bool success, ) = address(0).call('');
+    success;
+    require(vm.lastCallGas().gasTotalUsed >= 21_000, 'PAYLOAD_GAS_CHECK_REQUIRES_ISOLATION');
   }
 
   /**

--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -43,6 +43,17 @@ contract CommonTestBase is Test {
     );
   }
 
+  // EIP-7825 (Fusaka) per-tx gas cap, used as a conservative floor for every chain: a payload that fits
+  // within it is executable on any supported chain. Can be replaced with an on-chain read once EIP-8123
+  // is accepted, or overridden per chain where a higher limit is needed.
+  function _getMaxPayloadGas() internal view virtual returns (uint256) {
+    return 16_777_216;
+  }
+
+  function _assertPayloadGasWithinLimit(uint256 gasUsed) internal view {
+    assertLt(gasUsed, (_getMaxPayloadGas() * 95) / 100, 'TX_GAS_LIMIT_EXCEEDED'); // 5% is kept as a buffer
+  }
+
   /**
    * @notice deal doesn't support amounts stored in a script right now.
    * This function patches deal to mock and transfer funds instead.

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -106,8 +106,7 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
    * - diffing the config
    * - checking if the changes are plausible (no conflicting config changes etc)
    * - running an e2e testsuite over all assets
-   * @dev the calling test must run under isolation (`forge-config: default.isolate = true` or `--isolate`)
-   * for the payload gas-limit check to reflect real cold-storage transaction gas.
+   * @dev the calling test must run under isolation
    */
   function defaultTest(
     string memory reportName,

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -106,7 +106,10 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
    * - diffing the config
    * - checking if the changes are plausible (no conflicting config changes etc)
    * - running an e2e testsuite over all assets
-   * @dev the calling test must run under isolation
+   * @dev the calling test must run in foundry's isolation mode (the `--isolate` CLI flag, or the
+   * per-test isolate inline-config annotation) so each top-level call is metered as its own
+   * transaction. Otherwise the payload gas measurement reads warm storage and under-counts, and the
+   * gas-limit check reverts (see `_requireIsolation`).
    */
   function defaultTest(
     string memory reportName,

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -106,6 +106,8 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
    * - diffing the config
    * - checking if the changes are plausible (no conflicting config changes etc)
    * - running an e2e testsuite over all assets
+   * @dev the calling test must run under isolation (`forge-config: default.isolate = true` or `--isolate`)
+   * for the payload gas-limit check to reflect real cold-storage transaction gas.
    */
   function defaultTest(
     string memory reportName,
@@ -126,17 +128,19 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
     ReserveConfig[] memory configBefore = createConfigurationSnapshot(beforeString, pool);
     string memory afterString = string(abi.encodePacked(reportName, '_after'));
 
+    // Meter execution on a dedicated run: vm.startStateDiffRecording (needed for the diff below)
+    // suppresses isolate's transaction-level gas accounting, so gas must be measured without it.
+    // This run is reverted and has no effect on the recorded snapshot/diff.
     {
-      uint256 startGas = gasleft();
-
-      vm.startStateDiffRecording();
-      vm.recordLogs();
-
+      uint256 snapshotId = vm.snapshotState();
       executePayload(vm, payload, pool);
-
-      uint256 gasUsed = startGas - gasleft();
-      assertLt(gasUsed, (block.gaslimit * 95) / 100, 'BLOCK_GAS_LIMIT_EXCEEDED'); // 5% is kept as a buffer
+      _assertPayloadGasWithinLimit(vm.lastCallGas().gasTotalUsed);
+      vm.revertToState(snapshotId);
     }
+
+    vm.startStateDiffRecording();
+    vm.recordLogs();
+    executePayload(vm, payload, pool);
 
     string memory rawDiff = vm.getStateDiffJson();
     string memory logsJson = vm.getRecordedLogsJson();

--- a/src/ProtocolV4TestBase.sol
+++ b/src/ProtocolV4TestBase.sol
@@ -33,8 +33,7 @@ contract ProtocolV4TestBase is
   using SafeERC20 for IERC20;
 
   /// @notice Run the full V4 test suite: snapshot before, execute payload, snapshot after, diff, then e2e.
-  /// @dev the calling test must run under isolation (`forge-config: default.isolate = true` or `--isolate`)
-  /// for the payload gas-limit check to reflect real cold-storage transaction gas.
+  /// @dev the calling test must run under isolation
   function defaultTest(
     string memory reportName,
     ISpoke[] memory spokes,

--- a/src/ProtocolV4TestBase.sol
+++ b/src/ProtocolV4TestBase.sol
@@ -33,7 +33,10 @@ contract ProtocolV4TestBase is
   using SafeERC20 for IERC20;
 
   /// @notice Run the full V4 test suite: snapshot before, execute payload, snapshot after, diff, then e2e.
-  /// @dev the calling test must run under isolation
+  /// @dev the calling test must run in foundry's isolation mode (the `--isolate` CLI flag, or the
+  /// per-test isolate inline-config annotation) so each top-level call is metered as its own
+  /// transaction. Otherwise the payload gas measurement reads warm storage and under-counts, and the
+  /// gas-limit check reverts (see `_requireIsolation`).
   function defaultTest(
     string memory reportName,
     ISpoke[] memory spokes,

--- a/src/ProtocolV4TestBase.sol
+++ b/src/ProtocolV4TestBase.sol
@@ -33,6 +33,8 @@ contract ProtocolV4TestBase is
   using SafeERC20 for IERC20;
 
   /// @notice Run the full V4 test suite: snapshot before, execute payload, snapshot after, diff, then e2e.
+  /// @dev the calling test must run under isolation (`forge-config: default.isolate = true` or `--isolate`)
+  /// for the payload gas-limit check to reflect real cold-storage transaction gas.
   function defaultTest(
     string memory reportName,
     ISpoke[] memory spokes,
@@ -250,19 +252,19 @@ contract ProtocolV4TestBase is
   function _executePayloadWithRecording(
     address payload
   ) private returns (string memory rawDiff, string memory logsJson) {
-    uint256 startGas = gasleft();
+    address payloadsController = address(GovV3Helpers.getPayloadsController(block.chainid));
+
+    // Meter execution on a dedicated run: vm.startStateDiffRecording (needed for the diff below)
+    // suppresses isolate's transaction-level gas accounting, so gas must be measured without it.
+    // This run is reverted and has no effect on the recorded snapshot/diff.
+    uint256 snapshotId = vm.snapshotState();
+    GovV3Helpers.executePayload(vm, payload, payloadsController);
+    _assertPayloadGasWithinLimit(vm.lastCallGas().gasTotalUsed);
+    vm.revertToState(snapshotId);
+
     vm.startStateDiffRecording();
     vm.recordLogs();
-
-    GovV3Helpers.executePayload(
-      vm,
-      payload,
-      address(GovV3Helpers.getPayloadsController(block.chainid))
-    );
-
-    uint256 gasUsed = startGas - gasleft();
-    assertLt(gasUsed, (block.gaslimit * 95) / 100, 'BLOCK_GAS_LIMIT_EXCEEDED');
-
+    GovV3Helpers.executePayload(vm, payload, payloadsController);
     rawDiff = vm.getStateDiffJson();
     logsJson = vm.getRecordedLogsJson();
   }

--- a/tests/ProtocolV3TestBase.t.sol
+++ b/tests/ProtocolV3TestBase.t.sol
@@ -187,6 +187,11 @@ contract ProtocolV3TestMantleSnapshot is ProtocolV3TestBase {
 
   // overriding the executor storage check as payload artifacts does not exist
   function _validateNoExecutorStorageChange(string memory, address) internal view override {}
+
+  // Mantle's per-tx limit is well above the EIP-7825 floor; raise it so this payload fits.
+  function _getMaxPayloadGas() internal view override returns (uint256) {
+    return 30_000_000;
+  }
 }
 
 contract ProtocolV3TestPlausibilityEMode is ProtocolV3TestBase {

--- a/tests/ProtocolV3TestBase.t.sol
+++ b/tests/ProtocolV3TestBase.t.sol
@@ -157,6 +157,7 @@ contract ProtocolV3TestMegaEthSnapshot is ProtocolV3TestBase {
     vm.createSelectFork('megaeth', 7862955);
   }
 
+  /// forge-config: default.isolate = true
   function test_snapshotState() public {
     defaultTest(
       'megaeth',
@@ -173,6 +174,7 @@ contract ProtocolV3TestMantleSnapshot is ProtocolV3TestBase {
     vm.createSelectFork('mantle', 91335553);
   }
 
+  /// forge-config: default.isolate = true
   function test_snapshotState() public {
     defaultTest(
       'mantle',
@@ -297,6 +299,7 @@ contract ProtocolV3TestStorageValidation is ProtocolV3TestBase {
     vm.createSelectFork('mainnet', 24655671);
   }
 
+  /// forge-config: default.isolate = true
   function test_noExecutorStorageChange_passes() public {
     defaultTest(
       'V3StorageValidation_pass',
@@ -307,6 +310,7 @@ contract ProtocolV3TestStorageValidation is ProtocolV3TestBase {
     );
   }
 
+  /// forge-config: default.isolate = true
   function test_executorStorageChange_reverts() public {
     address payload = address(new PayloadWithStorage());
     vm.expectRevert();

--- a/tests/ProtocolV4TestBase.t.sol
+++ b/tests/ProtocolV4TestBase.t.sol
@@ -179,12 +179,14 @@ contract ProtocolV4TestSnapshot is ProtocolV4TestBaseTest {
 }
 
 contract ProtocolV4TestDefaultTest is ProtocolV4TestBaseTest {
+  /// forge-config: default.isolate = true
   function test_defaultTestWithPayload() public {
     string memory name = 'v4_emit_payload';
     defaultTest({reportName: name, payload: address(new PayloadWithEmit())});
     _cleanupArtifacts(name);
   }
 
+  /// forge-config: default.isolate = true
   function test_defaultTestNoE2E() public {
     string memory name = 'v4_no_e2e';
     defaultTest({
@@ -196,6 +198,7 @@ contract ProtocolV4TestDefaultTest is ProtocolV4TestBaseTest {
     _cleanupArtifacts(name);
   }
 
+  /// forge-config: default.isolate = true
   function test_defaultTestWithSeatbelt() public {
     string memory name = 'v4_seatbelt';
     defaultTest({
@@ -212,6 +215,7 @@ contract ProtocolV4TestDefaultTest is ProtocolV4TestBaseTest {
 }
 
 contract ProtocolV4TestStorageValidation is ProtocolV4TestBaseTest {
+  /// forge-config: default.isolate = true
   function test_noExecutorStorageChange_passes() public {
     string memory name = 'v4_storage_pass';
     defaultTest({
@@ -223,6 +227,7 @@ contract ProtocolV4TestStorageValidation is ProtocolV4TestBaseTest {
     _cleanupArtifacts(name);
   }
 
+  /// forge-config: default.isolate = true
   function test_executorStorageChange_reverts() public {
     string memory name = 'v4_storage_fail';
     address payload = address(new PayloadWithStorage());


### PR DESCRIPTION
## Problem

The payload gas-limit check in `ProtocolV3TestBase`/`ProtocolV4TestBase` was effectively a no-op and, where it did run, under-counted gas:

- It compared `gasleft()` usage against **`block.gaslimit`**, which foundry overrides to a huge value (e.g. `9223372036854775807` in the proposals `test` profile). `95%` of that is never exceeded, so the assertion never fired.
- It measured the payload **without isolation**, so execution ran against warm storage and reported far less than a real (cold) mainnet transaction.

## Fix

- **Real limit.** Replace `block.gaslimit` with `_getMaxPayloadGas()`, returning EIP-7825's per-transaction gas cap (`16_777_216`). It's applied as a conservative floor for every chain — a payload that fits within it is executable on any supported chain (no listed chain currently has a lower per-tx cap) — and is `virtual` so a specific chain/test can raise it where a higher limit is genuinely needed.
- **Accurate cold metering.** Measure the payload on a dedicated isolated run via `vm.lastCallGas().gasTotalUsed`, taken inside a `snapshotState`/`revertToState` so it has no effect on the recorded state diff. `vm.startStateDiffRecording()` (required for the diff + executor check) suppresses isolate's transaction-level gas accounting, so the metered run keeps recording **off** and the report is produced on a separate recorded run. See https://github.com/foundry-rs/foundry/issues/15381
- **Isolation.** Enable isolation on the gas-path tests via the inline `/// forge-config: default.isolate = true` annotation (per-test, no global config change).

## Validation

Verified against a real, near-limit payload (V4 onboarding, executed on mainnet at `15,657,968` gas per the on-chain transaction): the check now reports the gas **bit-for-bit** (`15,657,968`), vs the old check which passed it trivially against the overridden `block.gaslimit`.

### Why a single floor instead of per-chain values

The per-transaction cap is a consensus/admission rule (EIP-7825), not something observable from a fork or a read RPC: `block.gaslimit` is overridden by foundry, there is no RPC method for it, and simulation (`eth_call` / `eth_estimateGas` / `tenderly_simulateTransaction`) does not enforce it — only real `eth_sendRawTransaction` does. Hardcoding per-chain block limits is fragile (they drift, and several chains use dynamic limits), so we use the strictest deterministic cap (EIP-7825's `2^24`) as a floor for all chains, with the `virtual` override as the escape hatch.