### PR TITLE
fix: create report files before writing so snapshots work under isolation

### DIFF
--- a/src/ProtocolV2TestBase.sol
+++ b/src/ProtocolV2TestBase.sol
@@ -19,6 +19,7 @@ import {ProxyHelpers} from 'aave-v3-origin/../tests/utils/ProxyHelpers.sol';
 import {SeatbeltUtils} from './SeatbeltUtils.sol';
 import {GovV3Helpers} from './GovV3Helpers.sol';
 import {IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-address-book/GovernanceV3.sol';
+import {ReportFileUtils} from './dependencies/ReportFileUtils.sol';
 
 struct ReserveConfig {
   string symbol;
@@ -128,6 +129,7 @@ contract ProtocolV2TestBase is CommonTestBase, SeatbeltUtils, DiffUtils {
     ILendingPool pool
   ) public returns (ReserveConfig[] memory) {
     string memory path = string(abi.encodePacked('./reports/', reportName, '.json'));
+    ReportFileUtils.ensureExists(path);
     vm.writeFile(path, '{ "reserves": {}, "strategies": {}, "poolConfiguration": {} }');
     vm.serializeUint('root', 'chainId', block.chainid);
     ReserveConfig[] memory configs = _getReservesConfigs(pool);

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -13,6 +13,7 @@ import {WadRayMath} from 'aave-v3-origin/contracts/protocol/libraries/math/WadRa
 import {IDefaultInterestRateStrategyV2} from 'aave-v3-origin/contracts/interfaces/IDefaultInterestRateStrategyV2.sol';
 import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 import {DiffUtils} from './DiffUtils.sol';
+import {ReportFileUtils} from './dependencies/ReportFileUtils.sol';
 import {ProtocolV3TestBase as RawProtocolV3TestBase, ReserveConfig} from 'aave-v3-origin-tests/utils/ProtocolV3TestBase.sol';
 import {MockAggregator} from 'aave-v3-origin/contracts/mocks/oracle/CLAggregators/MockAggregator.sol';
 import {IInitializableAdminUpgradeabilityProxy} from './interfaces/IInitializableAdminUpgradeabilityProxy.sol';
@@ -45,6 +46,27 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
   using WadRayMath for uint256;
   using SafeERC20 for IERC20;
   using Strings for string;
+
+  // @dev Pre-create the report file so snapshot writes succeed under isolation. See ReportFileUtils.
+  function createConfigurationSnapshot(
+    string memory reportName,
+    IPool pool,
+    bool reserveConfigs,
+    bool strategyConfigs,
+    bool eModeConigs,
+    bool poolConfigs
+  ) public override returns (ReserveConfig[] memory) {
+    ReportFileUtils.ensureExists(string(abi.encodePacked('./reports/', reportName, '.json')));
+    return
+      super.createConfigurationSnapshot(
+        reportName,
+        pool,
+        reserveConfigs,
+        strategyConfigs,
+        eModeConigs,
+        poolConfigs
+      );
+  }
 
   // @dev Override to handle pre-v3.7 pools that lack getIsEModeCategoryIsolated
   function _writeEModeConfigs(string memory path, IPool pool) internal override {

--- a/src/dependencies/ReportFileUtils.sol
+++ b/src/dependencies/ReportFileUtils.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Vm} from 'forge-std/Vm.sol';
+
+/// @title ReportFileUtils
+/// @notice Ensures a report/snapshot file exists before it is written to.
+/// @dev Foundry bug: when isolation is enabled via the inline forge-config isolate annotation under a
+/// non-default profile (e.g. `FOUNDRY_PROFILE=test`), the per-test config loses its absolute `root`, so
+/// the `fs_permissions` check rejects creating a not-yet-existing file (only overwriting an existing one
+/// works). Snapshot generation therefore reverts on a clean checkout.
+/// `vm.ffi` bypasses the cheatcode `fs_permissions` check, so we pre-create the file with it and let
+/// the subsequent writes hit an existing path.
+/// See https://github.com/foundry-rs/foundry/issues/15512
+library ReportFileUtils {
+  Vm private constant vm = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+
+  function ensureExists(string memory path) internal {
+    string[] memory inputs = new string[](3);
+    inputs[0] = 'bash';
+    inputs[1] = '-c';
+    inputs[2] = string.concat(
+      'f=\'',
+      path,
+      '\'; mkdir -p "$(dirname "$f")"; [ -f "$f" ] || printf "{}" > "$f"'
+    );
+    vm.ffi(inputs);
+  }
+}

--- a/src/dependencies/ReportFileUtils.sol
+++ b/src/dependencies/ReportFileUtils.sol
@@ -20,7 +20,7 @@ library ReportFileUtils {
     inputs[0] = 'bash';
     inputs[1] = '-c';
     inputs[2] = string.concat(
-      'f=\'',
+      "f='",
       path,
       '\'; mkdir -p "$(dirname "$f")"; [ -f "$f" ] || printf "{}" > "$f"'
     );

--- a/src/dependencies/v4/V4DiffWriter.sol
+++ b/src/dependencies/v4/V4DiffWriter.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import {Vm} from 'forge-std/Vm.sol';
 import {Types} from 'src/dependencies/v4/Types.sol';
+import {ReportFileUtils} from 'src/dependencies/ReportFileUtils.sol';
 
 /// @title V4DiffWriter
 /// @notice Internal library for V4 JSON serialization.
@@ -14,6 +15,7 @@ library V4DiffWriter {
 
   function writeSnapshotJson(string memory reportName, Types.V4Snapshot memory snapshot) internal {
     string memory path = string.concat('./reports/', reportName, '.json');
+    ReportFileUtils.ensureExists(path);
     vm.writeFile(
       path,
       '{ "spokeReserves": {}, "spokeLiquidationConfigs": {}, "hubAssets": {}, "spokeConfigs": {}, "positionManagers": {}, "accessManagerRoles": {} }'


### PR DESCRIPTION
## Problem

Running a proposal test under isolation via the inline `forge-config` isolate annotation, on a non-default profile (e.g. the proposals repo runs `FOUNDRY_PROFILE=test`), makes `defaultTest` revert on a clean checkout:

```
vm.writeJson: the path ./reports/<name>_before.json is not allowed to be accessed for write operations
```

This is a foundry bug (reported in https://github.com/foundry-rs/foundry/issues/15512): under a non-default profile the inline-config annotation makes the per-test config lose its absolute `root`, so the `fs_permissions` check rejects creating a **not-yet-existing** file — only overwriting an existing one works. It surfaces now that the payload gas check enables isolation per-test.

## Fix

Pre-create the report/snapshot file via `vm.ffi` (which bypasses the cheatcode `fs_permissions` check) before the first write, so the subsequent writes hit an existing path. Wired into the report-writing paths for V2, V3 and V4 via a small `ReportFileUtils` helper. No-op once the file exists.

## Validation

Verified against the pending StkGho migrator proposal (V3, `FOUNDRY_PROFILE=test`, isolated): `test_defaultProposalExecution` and the rest of the suite pass on a clean checkout, where they previously reverted at the first report write.