### PR TITLE
feat: check previous values when updating reserves

### DIFF
--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -420,16 +420,29 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
       if (update.asset != expectedConfig.underlying) continue;
 
       if (update.ltv != EngineFlags.KEEP_CURRENT) {
+        require(expectedConfig.ltv != update.ltv, 'COLLATERAL_UPDATE_LTV_NO_CHANGE');
         expectedConfig.ltv = update.ltv;
       }
       if (update.liqThreshold != EngineFlags.KEEP_CURRENT) {
+        require(
+          expectedConfig.liquidationThreshold != update.liqThreshold,
+          'COLLATERAL_UPDATE_LIQ_THRESHOLD_NO_CHANGE'
+        );
         expectedConfig.liquidationThreshold = update.liqThreshold;
         expectedConfig.usageAsCollateralEnabled = update.liqThreshold != 0;
       }
       if (update.liqBonus != EngineFlags.KEEP_CURRENT) {
+        require(
+          expectedConfig.liquidationBonus != 100_00 + update.liqBonus,
+          'COLLATERAL_UPDATE_LIQ_BONUS_NO_CHANGE'
+        );
         expectedConfig.liquidationBonus = 100_00 + update.liqBonus;
       }
       if (update.liqProtocolFee != EngineFlags.KEEP_CURRENT) {
+        require(
+          expectedConfig.liquidationProtocolFee != update.liqProtocolFee,
+          'COLLATERAL_UPDATE_LIQ_PROTOCOL_FEE_NO_CHANGE'
+        );
         expectedConfig.liquidationProtocolFee = update.liqProtocolFee;
       }
     }
@@ -444,9 +457,11 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
       if (update.asset != expectedConfig.underlying) continue;
 
       if (update.supplyCap != EngineFlags.KEEP_CURRENT) {
+        require(expectedConfig.supplyCap != update.supplyCap, 'CAPS_UPDATE_SUPPLY_CAP_NO_CHANGE');
         expectedConfig.supplyCap = update.supplyCap;
       }
       if (update.borrowCap != EngineFlags.KEEP_CURRENT) {
+        require(expectedConfig.borrowCap != update.borrowCap, 'CAPS_UPDATE_BORROW_CAP_NO_CHANGE');
         expectedConfig.borrowCap = update.borrowCap;
       }
     }
@@ -461,12 +476,24 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
       if (update.asset != expectedConfig.underlying) continue;
 
       if (update.enabledToBorrow != EngineFlags.KEEP_CURRENT) {
+        require(
+          expectedConfig.borrowingEnabled != EngineFlags.toBool(update.enabledToBorrow),
+          'BORROW_UPDATE_ENABLED_NO_CHANGE'
+        );
         expectedConfig.borrowingEnabled = EngineFlags.toBool(update.enabledToBorrow);
       }
       if (update.reserveFactor != EngineFlags.KEEP_CURRENT) {
+        require(
+          expectedConfig.reserveFactor != update.reserveFactor,
+          'BORROW_UPDATE_RESERVE_FACTOR_NO_CHANGE'
+        );
         expectedConfig.reserveFactor = update.reserveFactor;
       }
       if (update.flashloanable != EngineFlags.KEEP_CURRENT) {
+        require(
+          expectedConfig.isFlashloanable != EngineFlags.toBool(update.flashloanable),
+          'BORROW_UPDATE_FLASHLOANABLE_NO_CHANGE'
+        );
         expectedConfig.isFlashloanable = EngineFlags.toBool(update.flashloanable);
       }
     }
@@ -481,6 +508,7 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
     for (uint256 i = 0; i < freezeAssets.length; i++) {
       if (freezeAssets[i] != expectedConfig.underlying) continue;
 
+      require(expectedConfig.isFrozen != frozenStates[i], 'FREEZE_UPDATE_NO_CHANGE');
       expectedConfig.isFrozen = frozenStates[i];
     }
   }

--- a/tests/ProtocolV3TestBase.t.sol
+++ b/tests/ProtocolV3TestBase.t.sol
@@ -353,6 +353,9 @@ contract ProtocolV3TestBaseReserveConfigChangesTest is ProtocolV3TestBase {
     uint256 expectedBorrowCap = _expectedCapsChanges()[0].borrowCap;
     assetBSupplyCap = bound(assetBSupplyCap, expectedBorrowCap, 1_000_000_000);
     assetBBorrowCap = bound(assetBBorrowCap, 0, assetBSupplyCap);
+    // the declared borrow cap change must be a real change, so the fuzzed
+    // pre-state borrow cap cannot already equal the expected new value
+    vm.assume(assetBBorrowCap != expectedBorrowCap);
     assetCSupplyCap = bound(assetCSupplyCap, 1, 1_000_000_000);
     assetCBorrowCap = bound(assetCBorrowCap, 0, assetCSupplyCap);
 
@@ -410,6 +413,65 @@ contract ProtocolV3TestBaseReserveConfigChangesTest is ProtocolV3TestBase {
 
     vm.expectRevert(bytes('_validateReserveConfig: InvalidSupplyCap()'));
     this.validateReserveConfigChanges(configsBefore, configsAfter);
+  }
+
+  function test_revertsWhenDeclaredCollateralLtvIsNoChange() public {
+    ReserveConfig[] memory configsBefore = _configsBefore();
+    configsBefore[0].ltv = _expectedCollateralChanges()[0].ltv;
+
+    vm.expectRevert(bytes('COLLATERAL_UPDATE_LTV_NO_CHANGE'));
+    this.validateReserveConfigChanges(configsBefore, _configsAfter());
+  }
+
+  function test_revertsWhenDeclaredCollateralLiqThresholdIsNoChange() public {
+    ReserveConfig[] memory configsBefore = _configsBefore();
+    configsBefore[0].liquidationThreshold = _expectedCollateralChanges()[0].liqThreshold;
+
+    vm.expectRevert(bytes('COLLATERAL_UPDATE_LIQ_THRESHOLD_NO_CHANGE'));
+    this.validateReserveConfigChanges(configsBefore, _configsAfter());
+  }
+
+  function test_revertsWhenDeclaredCollateralLiqBonusIsNoChange() public {
+    ReserveConfig[] memory configsBefore = _configsBefore();
+    configsBefore[0].liquidationBonus = 100_00 + _expectedCollateralChanges()[0].liqBonus;
+
+    vm.expectRevert(bytes('COLLATERAL_UPDATE_LIQ_BONUS_NO_CHANGE'));
+    this.validateReserveConfigChanges(configsBefore, _configsAfter());
+  }
+
+  function test_revertsWhenDeclaredBorrowCapIsNoChange() public {
+    ReserveConfig[] memory configsBefore = _configsBefore();
+    configsBefore[1].borrowCap = _expectedCapsChanges()[0].borrowCap;
+
+    vm.expectRevert(bytes('CAPS_UPDATE_BORROW_CAP_NO_CHANGE'));
+    this.validateReserveConfigChanges(configsBefore, _configsAfter());
+  }
+
+  function test_revertsWhenDeclaredBorrowingEnabledIsNoChange() public {
+    ReserveConfig[] memory configsBefore = _configsBefore();
+    configsBefore[1].borrowingEnabled = EngineFlags.toBool(
+      _expectedBorrowChanges()[0].enabledToBorrow
+    );
+
+    vm.expectRevert(bytes('BORROW_UPDATE_ENABLED_NO_CHANGE'));
+    this.validateReserveConfigChanges(configsBefore, _configsAfter());
+  }
+
+  function test_revertsWhenDeclaredReserveFactorIsNoChange() public {
+    ReserveConfig[] memory configsBefore = _configsBefore();
+    configsBefore[1].reserveFactor = _expectedBorrowChanges()[0].reserveFactor;
+
+    vm.expectRevert(bytes('BORROW_UPDATE_RESERVE_FACTOR_NO_CHANGE'));
+    this.validateReserveConfigChanges(configsBefore, _configsAfter());
+  }
+
+  function test_revertsWhenDeclaredFreezeIsNoChange() public {
+    ReserveConfig[] memory configsBefore = _configsBefore();
+    (, bool[] memory frozen) = _expectedFreezeChanges();
+    configsBefore[2].isFrozen = frozen[0];
+
+    vm.expectRevert(bytes('FREEZE_UPDATE_NO_CHANGE'));
+    this.validateReserveConfigChanges(configsBefore, _configsAfter());
   }
 
   function validateReserveConfigChanges(
@@ -527,9 +589,10 @@ contract ProtocolV3TestBaseReserveConfigChangesTest is ProtocolV3TestBase {
     ReserveConfig[] memory configsBefore
   ) internal pure returns (ReserveConfig[] memory) {
     ReserveConfig[] memory configs = new ReserveConfig[](4);
-    configs[0] = configsBefore[0];
-    configs[1] = configsBefore[1];
-    configs[2] = configsBefore[2];
+    // clone to avoid mutating the shared memory structs of `configsBefore`
+    configs[0] = _clone(configsBefore[0]);
+    configs[1] = _clone(configsBefore[1]);
+    configs[2] = _clone(configsBefore[2]);
     configs[0].ltv = 0;
     configs[0].liquidationThreshold = 0;
     configs[0].liquidationBonus = 105_00;


### PR DESCRIPTION
Add an extra assertion to v3 reserve updates to make sure the change is intentional and we're not updating to the same value by accident.