### PR TITLE
feat: add GSM events to eventDb

### DIFF
--- a/.changeset/arb-gsm-events.md
+++ b/.changeset/arb-gsm-events.md
@@ -1,0 +1,5 @@
+---
+'@aave-dao/aave-helpers-js': patch
+---
+
+Add GSM events to eventDb (BuyAsset, SellAsset, Seized, BurnAfterSeize, BackingProvided, ExposureCapUpdated, FeeStrategyUpdated, FeesDistributedToTreasury, GhoReserveUpdated, GhoTreasuryUpdated, SwapFreeze, TokensRescued) so GSM transaction logs decode.

--- a/.changeset/arb-gsm-events.md
+++ b/.changeset/arb-gsm-events.md
@@ -2,4 +2,4 @@
 '@aave-dao/aave-helpers-js': patch
 ---
 
-Add GSM events to eventDb (BuyAsset, SellAsset, Seized, BurnAfterSeize, BackingProvided, ExposureCapUpdated, FeeStrategyUpdated, FeesDistributedToTreasury, GhoReserveUpdated, GhoTreasuryUpdated, SwapFreeze, TokensRescued) so GSM transaction logs decode.
+Add GSM events to eventDb (BuyAsset, SellAsset, Seized, BurnAfterSeize, BackingProvided, ExposureCapUpdated, FeeStrategyUpdated, FeesDistributedToTreasury, GhoReserveUpdated, GhoTreasuryUpdated, SwapFreeze, TokensRescued) so GSM transaction logs decode. Also adds the GhoReserve (EntityAdded, EntityRemoved, GhoLimitUpdated, GhoUsed, GhoRestored, GhoTransferred) and GsmRegistry (GsmAdded, GsmRemoved) events emitted alongside them.

--- a/packages/aave-helpers-js/utils/eventDb.ts
+++ b/packages/aave-helpers-js/utils/eventDb.ts
@@ -3804,4 +3804,64 @@ export const eventDb: AbiEvent[] = [
     name: 'TokensRescued',
     type: 'event',
   },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, internalType: 'address', name: 'entity', type: 'address' }],
+    name: 'EntityAdded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, internalType: 'address', name: 'entity', type: 'address' }],
+    name: 'EntityRemoved',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'entity', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'limit', type: 'uint256' },
+    ],
+    name: 'GhoLimitUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'entity', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+    ],
+    name: 'GhoRestored',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'to', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+    ],
+    name: 'GhoTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'entity', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+    ],
+    name: 'GhoUsed',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, internalType: 'address', name: 'gsmAddress', type: 'address' }],
+    name: 'GsmAdded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, internalType: 'address', name: 'gsmAddress', type: 'address' }],
+    name: 'GsmRemoved',
+    type: 'event',
+  },
 ];

--- a/packages/aave-helpers-js/utils/eventDb.ts
+++ b/packages/aave-helpers-js/utils/eventDb.ts
@@ -3479,4 +3479,126 @@ export const eventDb: AbiEvent[] = [
     name: 'UserDataUpdated',
     type: 'event',
   },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'backer', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'ghoAmount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'remainingLoss', type: 'uint256' },
+    ],
+    name: 'BackingProvided',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'burner', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'ghoOutstanding', type: 'uint256' },
+    ],
+    name: 'BurnAfterSeize',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'originator', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'receiver', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'underlyingAmount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'ghoAmount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'fee', type: 'uint256' },
+    ],
+    name: 'BuyAsset',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: 'uint256', name: 'oldExposureCap', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'newExposureCap', type: 'uint256' },
+    ],
+    name: 'ExposureCapUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'oldFeeStrategy', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'newFeeStrategy', type: 'address' },
+    ],
+    name: 'FeeStrategyUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'ghoTreasury', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+    ],
+    name: 'FeesDistributedToTreasury',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: 'address', name: 'oldReserve', type: 'address' },
+      { indexed: false, internalType: 'address', name: 'newReserve', type: 'address' },
+    ],
+    name: 'GhoReserveUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'oldGhoTreasury', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'newGhoTreasury', type: 'address' },
+    ],
+    name: 'GhoTreasuryUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'seizer', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'recipient', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'underlyingAmount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'ghoOutstanding', type: 'uint256' },
+    ],
+    name: 'Seized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'originator', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'receiver', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'underlyingAmount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'ghoAmount', type: 'uint256' },
+      { indexed: false, internalType: 'uint256', name: 'fee', type: 'uint256' },
+    ],
+    name: 'SellAsset',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'freezer', type: 'address' },
+      { indexed: false, internalType: 'bool', name: 'enabled', type: 'bool' },
+    ],
+    name: 'SwapFreeze',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'tokenRescued', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'recipient', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amountRescued', type: 'uint256' },
+    ],
+    name: 'TokensRescued',
+    type: 'event',
+  },
 ];


### PR DESCRIPTION
Adds 12 missing events from the GSM implementation on Arbitrum (0x53E0cE250d06043414070100458546AaF4e284eD, impl 0x66c6ba44...fd855) so GSM transaction logs decode.

