### PR TITLE
chore: add RiskSteward events changeset

### DIFF
--- a/.changeset/decode-risk-steward-events.md
+++ b/.changeset/decode-risk-steward-events.md
@@ -1,0 +1,5 @@
+---
+'@aave-dao/aave-helpers-js': patch
+---
+
+Decode RiskSteward events in protocol diffs.


### PR DESCRIPTION
Adds the missing patch changeset for #784 so the release workflow versions and publishes `@aave-dao/aave-helpers-js` with the RiskSteward event decoding fix.