### PR TITLE
chore: bump address book

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -2,7 +2,7 @@
   "lib/aave-address-book": {
     "branch": {
       "name": "main",
-      "rev": "00c0d0b95d9410c66e5891bc49f6ecc0f428e7be"
+      "rev": "d0508f47f7eba3bb7c1d5dc5d96471d92025f4c3"
     }
   },
   "lib/forge-std": {


### PR DESCRIPTION
Bumps `lib/aave-address-book` from `v4.65.6` to `v4.65.8`, including the complete `IUmbrella` interface from aave-dao/aave-address-book#1528.

Keeps the Foundry lock revision synchronized with the submodule gitlink.