### PR TITLE
feat: add ethereum pool events to eventDb

### DIFF
--- a/.changeset/decode-pool-events.md
+++ b/.changeset/decode-pool-events.md
@@ -1,0 +1,5 @@
+---
+'@aave-dao/aave-helpers-js': patch
+---
+
+Decode additional Pool events (reserve state, liquidation grace period, flashloan premium, token upgrades) in protocol diffs.

--- a/.claude/skills/add-events/SKILL.md
+++ b/.claude/skills/add-events/SKILL.md
@@ -31,16 +31,16 @@ When the user wants to add events from a block explorer URL (e.g. etherscan, pol
    - If given a chain ID and address directly, use those
    - Strip any URL fragments (e.g. `#code`) and query parameters
 
-2. Run the script:
+2. Run the script (from the repo root):
 
    ```bash
-   cd /Volumes/sensitive/BGD/aave-helpers/packages/aave-helpers-js && npx tsx scripts/add-events.ts <chainId> <address>
+   cd packages/aave-helpers-js && npx tsx scripts/add-events.ts <chainId> <address>
    ```
 
-3. Run lint fix:
+3. Run lint fix (from the repo root):
 
    ```bash
-   cd /Volumes/sensitive/BGD/aave-helpers && npm run lint:fix
+   npm run lint:fix
    ```
 
 4. Report the results to the user (how many events were added, which ones).

--- a/packages/aave-helpers-js/utils/eventDb.ts
+++ b/packages/aave-helpers-js/utils/eventDb.ts
@@ -3682,4 +3682,142 @@ export const eventDb: AbiEvent[] = [
     name: 'RiskConfigSet',
     type: 'event',
   },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'proxy', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'implementation', type: 'address' },
+    ],
+    name: 'ATokenUpgraded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'uint8', name: 'categoryId', type: 'uint8' },
+      { indexed: false, internalType: 'bool', name: 'ltvzero', type: 'bool' },
+    ],
+    name: 'AssetLtvzeroInEModeChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'uint8', name: 'categoryId', type: 'uint8' },
+      { indexed: false, internalType: 'bool', name: 'isolated', type: 'bool' },
+    ],
+    name: 'EModeCategoryIsolationChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'oldFlashloanPremiumToProtocol',
+        type: 'uint128',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'newFlashloanPremiumToProtocol',
+        type: 'uint128',
+      },
+    ],
+    name: 'FlashloanPremiumToProtocolUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'oldFlashloanPremiumTotal',
+        type: 'uint128',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'newFlashloanPremiumTotal',
+        type: 'uint128',
+      },
+    ],
+    name: 'FlashloanPremiumTotalUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'uint40', name: 'gracePeriodUntil', type: 'uint40' },
+    ],
+    name: 'LiquidationGracePeriodChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, internalType: 'address', name: 'asset', type: 'address' }],
+    name: 'LiquidationGracePeriodDisabled',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'ltv', type: 'uint256' },
+    ],
+    name: 'PendingLtvChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'bool', name: 'active', type: 'bool' },
+    ],
+    name: 'ReserveActive',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'bool', name: 'frozen', type: 'bool' },
+    ],
+    name: 'ReserveFrozen',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'address', name: 'oldStrategy', type: 'address' },
+      { indexed: false, internalType: 'address', name: 'newStrategy', type: 'address' },
+    ],
+    name: 'ReserveInterestRateStrategyChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: false, internalType: 'bool', name: 'paused', type: 'bool' },
+    ],
+    name: 'ReservePaused',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'asset', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'proxy', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'implementation', type: 'address' },
+    ],
+    name: 'VariableDebtTokenUpgraded',
+    type: 'event',
+  },
 ];


### PR DESCRIPTION
## Changes

- Adds 13 missing Pool events to `packages/aave-helpers-js/utils/eventDb.ts`, pulled from the verified contract `0x64b761D848206f447Fe2dd461b0c635Ec39EbB27` on ethereum (proxy, implementation `0xff42ce30054dce7dc7c1282a9a497aa58eabce99`) via the `add-events` script:
  - `ATokenUpgraded(address,address,address)`
  - `AssetLtvzeroInEModeChanged(address,uint8,bool)`
  - `EModeCategoryIsolationChanged(uint8,bool)`
  - `FlashloanPremiumToProtocolUpdated(uint128,uint128)`
  - `FlashloanPremiumTotalUpdated(uint128,uint128)`
  - `LiquidationGracePeriodChanged(address,uint40)`
  - `LiquidationGracePeriodDisabled(address)`
  - `PendingLtvChanged(address,uint256)`
  - `ReserveActive(address,bool)`
  - `ReserveFrozen(address,bool)`
  - `ReserveInterestRateStrategyChanged(address,address,address)`
  - `ReservePaused(address,bool)`
  - `VariableDebtTokenUpgraded(address,address,address)`
- Updates the `add-events` skill to use paths relative to the repo root instead of a hardcoded local checkout path.