### PR TITLE
fix: model v3.7 freeze ltv zeroing & fix drained EURe deal source

### DIFF
--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -146,7 +146,7 @@ contract CommonTestBase is Test {
     }
     if (block.chainid == ChainIds.GNOSIS) {
       if (asset == AaveV3GnosisAssets.EURe_UNDERLYING) {
-        vm.prank(0x845C8bc94610807fCbaB5dd2bc7aC9DAbaFf3c55);
+        vm.prank(AaveV3GnosisAssets.EURe_A_TOKEN);
         IERC20(asset).transfer(user, amount);
         return true;
       }

--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -146,7 +146,10 @@ contract CommonTestBase is Test {
     }
     if (block.chainid == ChainIds.GNOSIS) {
       if (asset == AaveV3GnosisAssets.EURe_UNDERLYING) {
-        vm.prank(AaveV3GnosisAssets.EURe_A_TOKEN);
+        // uniswap v3 USDC.e/EURe pool; EURe balances are shared between the legacy and current
+        // token addresses via Monerium's external balance storage, so the pool's liquidity is
+        // transferable through the legacy address aave uses as underlying
+        vm.prank(0x93b7a3d164585B52f096F6eAE1EC42ee267878E1);
         IERC20(asset).transfer(user, amount);
         return true;
       }

--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -146,9 +146,6 @@ contract CommonTestBase is Test {
     }
     if (block.chainid == ChainIds.GNOSIS) {
       if (asset == AaveV3GnosisAssets.EURe_UNDERLYING) {
-        // uniswap v3 USDC.e/EURe pool; EURe balances are shared between the legacy and current
-        // token addresses via Monerium's external balance storage, so the pool's liquidity is
-        // transferable through the legacy address aave uses as underlying
         vm.prank(0x93b7a3d164585B52f096F6eAE1EC42ee267878E1);
         IERC20(asset).transfer(user, amount);
         return true;

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -330,8 +330,26 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
     ReserveConfig[] memory allConfigsAfter = _getReservesConfigs(pool);
 
     _validateReserveConfigChanges(allConfigsBefore, allConfigsAfter, updatedAssets);
+    _validatePendingLtvs(pool, allConfigsBefore);
 
     return (allConfigsBefore, allConfigsAfter);
+  }
+
+  function _validatePendingLtvs(IPool pool, ReserveConfig[] memory allConfigsBefore) internal view {
+    (address[] memory freezeAssets, bool[] memory frozenStates) = _expectedFreezeChanges();
+    if (freezeAssets.length == 0) return;
+
+    IPoolConfigurator configurator = IPoolConfigurator(
+      IPoolAddressesProvider(pool.ADDRESSES_PROVIDER()).getPoolConfigurator()
+    );
+    for (uint256 i = 0; i < freezeAssets.length; i++) {
+      if (!frozenStates[i]) continue;
+      require(
+        configurator.getPendingLtv(freezeAssets[i]) ==
+          _findReserveConfig(allConfigsBefore, freezeAssets[i]).ltv,
+        'FREEZE_UPDATE_INVALID_PENDING_LTV'
+      );
+    }
   }
 
   function _validateReserveConfigChanges(
@@ -510,9 +528,6 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
 
       require(expectedConfig.isFrozen != frozenStates[i], 'FREEZE_UPDATE_NO_CHANGE');
       expectedConfig.isFrozen = frozenStates[i];
-      // since v3.7 freezing a reserve also zeroes its ltv, parking the previous value in the
-      // configurator's pendingLtv; unfreezing does not restore it (that requires an explicit
-      // setReserveLtvzero(asset, false))
       if (frozenStates[i]) {
         expectedConfig.ltv = 0;
       }

--- a/src/ProtocolV3TestBase.sol
+++ b/src/ProtocolV3TestBase.sol
@@ -510,6 +510,12 @@ contract ProtocolV3TestBase is RawProtocolV3TestBase, SeatbeltUtils, CommonTestB
 
       require(expectedConfig.isFrozen != frozenStates[i], 'FREEZE_UPDATE_NO_CHANGE');
       expectedConfig.isFrozen = frozenStates[i];
+      // since v3.7 freezing a reserve also zeroes its ltv, parking the previous value in the
+      // configurator's pendingLtv; unfreezing does not restore it (that requires an explicit
+      // setReserveLtvzero(asset, false))
+      if (frozenStates[i]) {
+        expectedConfig.ltv = 0;
+      }
     }
   }
 

--- a/tests/CommonTestBase.t.sol
+++ b/tests/CommonTestBase.t.sol
@@ -2,8 +2,10 @@
 pragma solidity ^0.8.0;
 
 import 'forge-std/Test.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {CommonTestBase} from '../src/CommonTestBase.sol';
 import {AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {AaveV3GnosisAssets} from 'aave-address-book/AaveV3Gnosis.sol';
 
 contract CommonTestBaseTest is CommonTestBase {
   function setUp() public {
@@ -18,5 +20,16 @@ contract CommonTestBaseTest is CommonTestBase {
     assertEq(this.call(), address(this));
     deal2(AaveV2EthereumAssets.USDC_UNDERLYING, address(this), 100e6);
     assertEq(this.call(), address(this));
+  }
+}
+
+contract CommonTestBaseGnosisTest is CommonTestBase {
+  function setUp() public {
+    vm.createSelectFork('gnosis');
+  }
+
+  function test_deal2_EURe() public {
+    deal2(AaveV3GnosisAssets.EURe_UNDERLYING, address(this), 100e18);
+    assertEq(IERC20(AaveV3GnosisAssets.EURe_UNDERLYING).balanceOf(address(this)), 100e18);
   }
 }

--- a/tests/ProtocolV3TestBase.t.sol
+++ b/tests/ProtocolV3TestBase.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import 'forge-std/Test.sol';
 import {ProtocolV3TestBase, ReserveConfig, ExpectedListing} from '../src/ProtocolV3TestBase.sol';
 import {IPool, IPoolAddressesProvider, IPoolConfigurator} from 'aave-address-book/AaveV3.sol';
-import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 import {AaveV3EthereumEtherFi} from 'aave-address-book/AaveV3EthereumEtherFi.sol';
 import {AaveV3Polygon, AaveV3PolygonAssets} from 'aave-address-book/AaveV3Polygon.sol';
 import {AaveV3Optimism, AaveV3OptimismAssets} from 'aave-address-book/AaveV3Optimism.sol';
@@ -467,7 +467,6 @@ contract ProtocolV3TestBaseReserveConfigChangesTest is ProtocolV3TestBase {
 
   function test_revertsWhenFrozenReserveLtvIsNotZeroed() public {
     ReserveConfig[] memory configsAfter = _configsAfter();
-    // freezing zeroes the ltv since v3.7, so a frozen reserve keeping its ltv must be rejected
     configsAfter[2].ltv = _configsBefore()[2].ltv;
 
     vm.expectRevert(bytes('_validateReserveConfig: InvalidLtv()'));
@@ -653,6 +652,53 @@ contract ProtocolV3TestBaseReserveConfigChangesTest is ProtocolV3TestBase {
         virtualBalance: 0,
         aTokenUnderlyingBalance: 0
       });
+  }
+}
+
+contract PayloadFreezeWeth {
+  function execute() external {
+    AaveV3Ethereum.POOL_CONFIGURATOR.setReserveFreeze(AaveV3EthereumAssets.WETH_UNDERLYING, true);
+  }
+}
+
+contract ProtocolV3TestBaseFreezePendingLtvTest is ProtocolV3TestBase {
+  function setUp() public {
+    vm.createSelectFork('mainnet', 25848520);
+  }
+
+  function test_reserveConfigChangesTest_freeze() public {
+    address[] memory updatedAssets = new address[](1);
+    updatedAssets[0] = AaveV3EthereumAssets.WETH_UNDERLYING;
+
+    (ReserveConfig[] memory configsBefore, ReserveConfig[] memory configsAfter) = reserveConfigChangesTest(
+      AaveV3Ethereum.POOL,
+      address(new PayloadFreezeWeth()),
+      updatedAssets
+    );
+
+    ReserveConfig memory wethBefore = _findReserveConfig(
+      configsBefore,
+      AaveV3EthereumAssets.WETH_UNDERLYING
+    );
+    ReserveConfig memory wethAfter = _findReserveConfig(
+      configsAfter,
+      AaveV3EthereumAssets.WETH_UNDERLYING
+    );
+    assertGt(wethBefore.ltv, 0);
+    assertEq(wethAfter.ltv, 0);
+    assertTrue(wethAfter.isFrozen);
+  }
+
+  function _expectedFreezeChanges()
+    internal
+    pure
+    override
+    returns (address[] memory assets, bool[] memory frozen)
+  {
+    assets = new address[](1);
+    frozen = new bool[](1);
+    assets[0] = AaveV3EthereumAssets.WETH_UNDERLYING;
+    frozen[0] = true;
   }
 }
 

--- a/tests/ProtocolV3TestBase.t.sol
+++ b/tests/ProtocolV3TestBase.t.sol
@@ -465,6 +465,15 @@ contract ProtocolV3TestBaseReserveConfigChangesTest is ProtocolV3TestBase {
     this.validateReserveConfigChanges(configsBefore, _configsAfter());
   }
 
+  function test_revertsWhenFrozenReserveLtvIsNotZeroed() public {
+    ReserveConfig[] memory configsAfter = _configsAfter();
+    // freezing zeroes the ltv since v3.7, so a frozen reserve keeping its ltv must be rejected
+    configsAfter[2].ltv = _configsBefore()[2].ltv;
+
+    vm.expectRevert(bytes('_validateReserveConfig: InvalidLtv()'));
+    this.validateReserveConfigChanges(_configsBefore(), configsAfter);
+  }
+
   function test_revertsWhenDeclaredFreezeIsNoChange() public {
     ReserveConfig[] memory configsBefore = _configsBefore();
     (, bool[] memory frozen) = _expectedFreezeChanges();
@@ -601,6 +610,7 @@ contract ProtocolV3TestBaseReserveConfigChangesTest is ProtocolV3TestBase {
     configs[1].borrowingEnabled = false;
     configs[1].reserveFactor = 25_00;
     configs[2].isFrozen = true;
+    configs[2].ltv = 0;
     configs[3] = _reserveConfig('ASSET_D', ASSET_D, 50_00, 60_00, true, 1_000, 200);
     configs[3].decimals = 6;
     configs[3].liquidationBonus = 105_00;


### PR DESCRIPTION
## `_applyFreezeUpdates`: model v3.7 freeze semantics

Since v3.7, `PoolConfigurator.setReserveFreeze(asset, true)` also zeroes the reserve's ltv on the config bitmap, parking the previous value in `_pendingLtv` (plus flipping the ltv0 bit in e-mode categories). `_applyFreezeUpdates` only flipped `isFrozen`, so `reserveConfigChangesTest` failed with `_validateReserveConfig: InvalidLtv()` for any payload freezing a reserve with non-zero ltv.

`_applyFreezeUpdates` now sets the expected ltv to 0 on freeze, and `reserveConfigChangesTest` additionally asserts `getPendingLtv(asset)` equals the pre-freeze ltv for every declared freeze (`_validatePendingLtvs`). On unfreeze the expected ltv is intentionally left unchanged: per v3.7 (`PoolConfigurator.setReserveFreeze` + origin's `test_unfreezeReserve_pendingSetToLtv`), unfreezing does **not** restore the ltv — that requires an explicit `setReserveLtvzero(asset, false)`. `_validateReserveConfigChanges` stays `pure`, so no signature changes.

- fixture updated: frozen ASSET_C now expects ltv 0
- new regression tests: `test_revertsWhenFrozenReserveLtvIsNotZeroed` (unit) and `ProtocolV3TestBaseFreezePendingLtvTest.test_reserveConfigChangesTest_freeze`, which executes a WETH-freezing payload against the live mainnet configurator and checks ltv zeroing + pendingLtv parking end to end

## `_patchedDeal`: EURe whale on Gnosis is drained

The EURe deal source `0x845C8bc94610807fCbaB5dd2bc7aC9DAbaFf3c55` was drained early Aug 2026 (balance now ~0.0025 EURe), so every e2e dealing EURe reverted with `ERC20InsufficientBalance` on recent fork blocks. Switched the source to the uniswap v3 USDC.e/EURe pool (`0x93b7a3d164585B52f096F6eAE1EC42ee267878E1`, ~157k EURe) — deliberately not the aEURe aToken, to avoid desyncing the accounting of the market under test. Note the pool's EURe is the current token address (`0x420C...`) while aave's underlying is the legacy one (`0xcB44...`); Monerium tokens share an external balance storage, so the pool's liquidity is transferable through the legacy address.

- new regression test on a latest-block Gnosis fork: `CommonTestBaseGnosisTest.test_deal2_EURe`

## Testing

- all `ProtocolV3TestBaseReserveConfigChanges*` unit tests pass (17/17)
- `test_reserveConfigChangesTest_freeze` passes on a mainnet fork (block 25848520)
- `test_deal2_EURe` passes on a latest-block Gnosis fork
- full suite: 312 passed; the only failure is `test_defaultTestWithExplicitPayloadsController`, whose Ink RPC currently 500s on archive state queries at the pinned block — fails identically on unmodified `main`

Once released, downstream `20260826_Multi_LowAdoptionAssetDeprecationOnAaveV3` tests can drop the manual `_expectedCollateralChanges()` ltv-0 overrides and the Gnosis whale re-funding in `setUp`.