### PR TITLE
chore: bump toolbox, add V4 e2e hooks

### DIFF
--- a/.changeset/toolbox-bump.md
+++ b/.changeset/toolbox-bump.md
@@ -1,0 +1,5 @@
+---
+'@aave-dao/aave-helpers-js': minor
+---
+
+Bump `@aave-dao/toolbox` to 0.6.1 for the latest chain list.

--- a/packages/aave-helpers-js/package.json
+++ b/packages/aave-helpers-js/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@aave-dao/aave-address-book": "^4.65.6",
-    "@aave-dao/toolbox": "^0.5.0",
+    "@aave-dao/toolbox": "^0.6.1",
     "commander": "^14.0.3",
     "find-object-paths": "^1.1.0",
     "viem": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^4.65.6
         version: 4.65.6(viem@2.45.3(typescript@5.9.3)(zod@4.3.6))
       '@aave-dao/toolbox':
-        specifier: ^0.5.0
-        version: 0.5.0(prettier-plugin-solidity@1.4.3(prettier@3.5.3))(prettier@3.5.3)(viem@2.45.3(typescript@5.9.3)(zod@4.3.6))
+        specifier: ^0.6.1
+        version: 0.6.1(prettier-plugin-solidity@1.4.3(prettier@3.5.3))(prettier@3.5.3)(viem@2.45.3(typescript@5.9.3)(zod@4.3.6))
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -71,8 +71,8 @@ packages:
     peerDependencies:
       viem: ^2.23.5
 
-  '@aave-dao/toolbox@0.5.0':
-    resolution: {integrity: sha512-tmTEt/zWvS2EdoTv9CRjbKE/8etin8P/vSalbt19qLQw62UmaF9k/7QecvlNlhJodOE3ZAjeiOEbdgq0gj7e3Q==}
+  '@aave-dao/toolbox@0.6.1':
+    resolution: {integrity: sha512-8xOf1XDa6VGwp2DvILlhBzLZej+DfwAPCZT6NVK/mZN9uUAdF1DyMBcqYY0X6QsWe7DrzGzQGJrzGYo6e4gSvg==}
     engines: {node: '>=22'}
     peerDependencies:
       prettier: ^3.5.2
@@ -1353,7 +1353,7 @@ snapshots:
     dependencies:
       viem: 2.45.3(typescript@5.9.3)(zod@4.3.6)
 
-  '@aave-dao/toolbox@0.5.0(prettier-plugin-solidity@1.4.3(prettier@3.5.3))(prettier@3.5.3)(viem@2.45.3(typescript@5.9.3)(zod@4.3.6))':
+  '@aave-dao/toolbox@0.6.1(prettier-plugin-solidity@1.4.3(prettier@3.5.3))(prettier@3.5.3)(viem@2.45.3(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       bs58: 6.0.0
       diff: 8.0.4

--- a/src/dependencies/v4/GatewayScenarios.sol
+++ b/src/dependencies/v4/GatewayScenarios.sol
@@ -25,6 +25,8 @@ abstract contract GatewayScenarios is Helpers {
     INativeTokenGateway gateway,
     ISpoke spoke
   ) internal view returns (bool found, Types.ReserveInfo memory info) {
+    // Markets without a NativeTokenGateway (e.g. Arc) bind address(0).
+    if (address(gateway) == address(0)) return (false, info);
     address weth = gateway.NATIVE_TOKEN_WRAPPER();
     Types.ReserveInfo[] memory allReserves = _getReserveInfo(spoke);
     for (uint256 i; i < allReserves.length; i++) {

--- a/src/dependencies/v4/Helpers.sol
+++ b/src/dependencies/v4/Helpers.sol
@@ -45,7 +45,9 @@ abstract contract Helpers is Actions {
   }
 
   /// @notice Build ReserveInfo[] for all reserves on a spoke.
-  function _getReserveInfo(ISpoke spoke) internal view returns (Types.ReserveInfo[] memory) {
+  function _getReserveInfo(
+    ISpoke spoke
+  ) internal view virtual returns (Types.ReserveInfo[] memory) {
     uint256 count = spoke.getReserveCount();
     Types.ReserveInfo[] memory info = new Types.ReserveInfo[](count);
 


### PR DESCRIPTION
## What

`packages/aave-helpers-js`
- Bump `@aave-dao/toolbox` to `^0.6.1` for the current chain list. Changeset: minor.

`src/dependencies/v4`
- `Helpers._getReserveInfo` is `internal view virtual`, so a chain binding or a proposal test can filter which reserves the e2e suite exercises.
- `GatewayScenarios._findNativeTokenReserveInfo` returns not-found when the market binds no NativeTokenGateway instead of calling `address(0)`.

## Verified

- `pnpm build` and `pnpm test` in `packages/aave-helpers-js`: 74 tests pass.
- A V4 proposal test suite using both hooks passes against this branch.