### PR TITLE
feat: fund native-coin ERC20s through vm.deal in _patchedDeal

### DIFF
--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -86,7 +86,11 @@ contract CommonTestBase is Test {
    * @param amount the amount to deal
    * @return bool true if the caller has changed due to prank usage
    */
-  function _patchedDeal(address asset, address user, uint256 amount) internal returns (bool) {
+  function _patchedDeal(
+    address asset,
+    address user,
+    uint256 amount
+  ) internal virtual returns (bool) {
     if (block.chainid == ChainIds.MAINNET) {
       // FXS
       if (asset == 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0) {
@@ -191,7 +195,7 @@ contract CommonTestBase is Test {
    * @param user to deal to
    * @param amount to deal
    */
-  function deal2(address asset, address user, uint256 amount) internal {
+  function deal2(address asset, address user, uint256 amount) internal virtual {
     (VmSafe.CallerMode mode, address oldSender, ) = vm.readCallers();
     if (mode != VmSafe.CallerMode.None) vm.stopPrank();
     bool patched = _patchedDeal(asset, user, amount);

--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -15,6 +15,7 @@ import {AaveV3MonadAssets} from 'aave-address-book/AaveV3Monad.sol';
 import {AaveV3ArbitrumAssets} from 'aave-address-book/AaveV3Arbitrum.sol';
 import {AaveV3GnosisAssets} from 'aave-address-book/AaveV3Gnosis.sol';
 import {AaveV3BaseAssets} from 'aave-address-book/AaveV3Base.sol';
+import {AaveV4ArcAssets} from 'aave-address-book/AaveV4Arc.sol';
 import {ChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
 import {IPool} from 'aave-address-book/AaveV3.sol';
 import {IPayloadsControllerCore} from 'aave-address-book/GovernanceV3.sol';
@@ -171,6 +172,13 @@ contract CommonTestBase is Test {
       // CELO
       if (asset == 0x471EcE3750Da237f93B8E339c536989b8978a438) {
         vm.deal(user, amount);
+        return true;
+      }
+    }
+    if (block.chainid == ChainIds.ARC) {
+      // USDC is the native coin: the ERC20 reports account.balance / 1e12
+      if (asset == AaveV4ArcAssets.USDC_UNDERLYING) {
+        vm.deal(user, amount * 1e12);
         return true;
       }
     }


### PR DESCRIPTION
## What

- `_patchedDeal` gains a branch for ERC20s that are views over the chain's native coin. `deal()` searches storage for a balance slot; such tokens have none, so the search corrupts a slot and later transfers panic. `vm.deal` on the native balance is the working equivalent, the same approach the Celo branch already uses. First entry: Arc USDC (`AaveV4ArcAssets.USDC_UNDERLYING`, 6 decimals over an 18-decimal native balance).
- `deal2` and `_patchedDeal` are `internal virtual`, so a chain binding or a single test can supply its own funding path without a helpers release.

## Verified

- Builds against the pinned address book.
- A V4 proposal e2e suite on an Arc fork (arc-foundry, `FOUNDRY_NETWORK=arc`) passes with USDC included once this is in place; without it `repay` panics inside `Hub.restore`.